### PR TITLE
Fixed incorrect CORE-V hwlp masks

### DIFF
--- a/gas/ChangeLog.COREV
+++ b/gas/ChangeLog.COREV
@@ -1,3 +1,8 @@
+2020-10-05  Jessica Mills <jessica.mills@embecosm.com>
+
+	* config/tc-riscv.c: Fixed issue arising from incorrect CORE-V
+	hardware loop masks and added support for xcorevhwlp.
+
 2020-09-10  Pietra Ferreira  <pietra.ferreira@embecosm.com>
 
 	* config/tc-riscv.c: Added CORE-V harware loop support.

--- a/gas/config/tc-riscv.c
+++ b/gas/config/tc-riscv.c
@@ -242,7 +242,8 @@ riscv_multi_subset_supports (enum riscv_insn_class insn_class)
 
     case INSN_CLASS_Q: return riscv_subset_supports ("q");
 
-    case INSN_CLASS_COREV: return riscv_subset_supports ("xcorev");
+    case INSN_CLASS_COREV_HWLP:
+      return riscv_subset_supports ("xcorevhwlp") || riscv_subset_supports ("xcorev");
 
     default:
       as_fatal ("Unreachable");
@@ -962,7 +963,7 @@ validate_riscv_insn (const struct riscv_opcode *opc, int length)
       case 'd':
 	if (*p == 'i')
 	  {
-	    used_bits |= (0xf00 |(ENCODE_I1TYPE_LN(-1U))); /* Bits 11:08 preset to 0 */
+	    used_bits |= ENCODE_I1TYPE_LN(-1U);
 	    ++p;
 	    break;
 	  }

--- a/include/ChangeLog.COREV
+++ b/include/ChangeLog.COREV
@@ -1,3 +1,9 @@
+2020-10-05  Jessica Mills <jessica.mills@embecosm.com>
+
+	* opcode/riscv-opc.h: Fixed incorrect masks for CORE-V hardware loop
+	instructions.
+	* opcode/riscv.h: Added support for xcorevhwlp.
+
 2020-09-10  Pietra Ferreira  <pietra.ferreira@embecosm.com>
 
 	* elf/riscv.h: Added CORE-V hardware loop specific relocations.

--- a/include/opcode/riscv-opc.h
+++ b/include/opcode/riscv-opc.h
@@ -853,12 +853,12 @@
 
 /* CORE-V Specific Instructions  */
 /* Hardware loops  */
-#define MASK_HWLP_STARTI 0x000ff07f
-#define MASK_HWLP_ENDI   0x000ff07f
-#define MASK_HWLP_COUNT  0xfff0707f
-#define MASK_HWLP_COUNTI 0x000ff07f
-#define MASK_HWLP_SETUP  0x0000707f
-#define MASK_HWLP_SETUPI 0x0000707f
+#define MASK_HWLP_STARTI 0x000fff7f
+#define MASK_HWLP_ENDI   0x000fff7f
+#define MASK_HWLP_COUNT  0xfff07f7f
+#define MASK_HWLP_COUNTI 0x000fff7f
+#define MASK_HWLP_SETUP  0x00007f7f
+#define MASK_HWLP_SETUPI 0x00007f7f
 
 #define MATCH_HWLP_STARTI 0x0007b
 #define MATCH_HWLP_ENDI   0x0107b

--- a/include/opcode/riscv.h
+++ b/include/opcode/riscv.h
@@ -338,7 +338,7 @@ enum riscv_insn_class
    INSN_CLASS_D_AND_C,
    INSN_CLASS_F_AND_C,
    INSN_CLASS_Q,
-   INSN_CLASS_COREV,
+   INSN_CLASS_COREV_HWLP,
   };
 
 /* This structure holds information for a particular instruction.  */

--- a/opcodes/ChangeLog.COREV
+++ b/opcodes/ChangeLog.COREV
@@ -1,3 +1,7 @@
+2020-10-08  Jessica Mills  <jessica.mills@embecosm.com>
+
+	* riscv-opc.c: Added support for corevhwlp.
+
 2020-09-10  Pietra Ferreira  <pietra.ferreira@embecosm.com>
 
 	* riscv-dis.c: Added CORE-V hardware loop support.

--- a/opcodes/riscv-opc.c
+++ b/opcodes/riscv-opc.c
@@ -789,12 +789,12 @@ const struct riscv_opcode riscv_opcodes[] =
 
 /* CORE-V Specific Opcodes.  */
 /* Hardware loops  */
-{"cv.starti", 0, INSN_CLASS_COREV, "di,b1",    	MATCH_HWLP_STARTI, MASK_HWLP_STARTI,match_opcode, 0},
-{"cv.endi",   0, INSN_CLASS_COREV, "di,b1",    	MATCH_HWLP_ENDI,   MASK_HWLP_ENDI,  match_opcode, 0},
-{"cv.count",  0, INSN_CLASS_COREV, "di,s",     	MATCH_HWLP_COUNT,  MASK_HWLP_COUNT, match_opcode, 0},
-{"cv.counti", 0, INSN_CLASS_COREV, "di,ji",    	MATCH_HWLP_COUNTI, MASK_HWLP_COUNTI,match_opcode, 0},
-{"cv.setup",  0, INSN_CLASS_COREV, "di,s,b1",  	MATCH_HWLP_SETUP,  MASK_HWLP_SETUP, match_opcode, 0},
-{"cv.setupi", 0, INSN_CLASS_COREV, "di,ji,b2", 	MATCH_HWLP_SETUPI, MASK_HWLP_SETUPI,match_opcode, 0},
+{"cv.starti", 0, INSN_CLASS_COREV_HWLP, "di,b1",    	MATCH_HWLP_STARTI, MASK_HWLP_STARTI,match_opcode, 0},
+{"cv.endi",   0, INSN_CLASS_COREV_HWLP, "di,b1",    	MATCH_HWLP_ENDI,   MASK_HWLP_ENDI,  match_opcode, 0},
+{"cv.count",  0, INSN_CLASS_COREV_HWLP, "di,s",     	MATCH_HWLP_COUNT,  MASK_HWLP_COUNT, match_opcode, 0},
+{"cv.counti", 0, INSN_CLASS_COREV_HWLP, "di,ji",    	MATCH_HWLP_COUNTI, MASK_HWLP_COUNTI,match_opcode, 0},
+{"cv.setup",  0, INSN_CLASS_COREV_HWLP, "di,s,b1",  	MATCH_HWLP_SETUP,  MASK_HWLP_SETUP, match_opcode, 0},
+{"cv.setupi", 0, INSN_CLASS_COREV_HWLP, "di,ji,b2", 	MATCH_HWLP_SETUPI, MASK_HWLP_SETUPI,match_opcode, 0},
 
 /* Terminate the list.  */
 {0, 0, INSN_CLASS_NONE, 0, 0, 0, 0, 0}


### PR DESCRIPTION
gas/ChangeLog.COREV:

	* config/tc-riscv.c: Fixed issue arising from incorrect CORE-V
        hardware loop masks and added support for xcorevhwlp.

include/ChangeLog.COREV:

	* opcode/riscv-opc.h: Fixed incorrect masks for CORE-V hardware loop
        instructions.
	* opcode/riscv.h: Added support for xcorevhwlp.

opcodes/ChangeLog.COREV:

	* riscv-opc.c: Added support for corevhwlp.

Signed-off-by: Mary Bennett <mary.bennett@embecosm.com>