### PR TITLE
Renamed EXTRACT and ENCODE macros.

### DIFF
--- a/bfd/ChangeLog.COREV
+++ b/bfd/ChangeLog.COREV
@@ -1,3 +1,13 @@
+2020-11-10  Mary Bennett  <mary.bennett@embecosm.com>
+
+	* elfnn-riscv.c (perform_relocation): Renamed macros for clarity -
+	ENCODE_I1TYPE_UIMM -> ENCODE_CV_HWLP_UIMM5
+	ENCODE_I1TYPE_LN   -> ENCODE_CV_HWLP_LN
+	* elfxx-riscv.c: Renamed macros for clarity -
+	EXTRACT_I1TYPE_UIMM-> EXTRACT_CV_HWLP_UIMM5
+	EXTRACT_I1TYPE_LN  -> EXTRACT_CV_HWLP_LN
+	EXTRACT_ITYPE_UIMM -> EXTRACT_CV_HWLP_UIMM12
+
 2020-09-10  Pietra Ferreira  <pietra.ferreira@embecosm.com>
 
 	* bfd-in2.h: Added CORE-V hardware loop specific relocations.

--- a/bfd/elfnn-riscv.c
+++ b/bfd/elfnn-riscv.c
@@ -1340,7 +1340,7 @@ perform_relocation (const reloc_howto_type *howto,
       break;
 
     case R_RISCV_CVPCREL_URS1:
-      value = ENCODE_I1TYPE_UIMM (value >> howto->rightshift);
+      value = ENCODE_CV_HWLP_UIMM5 (value >> howto->rightshift);
       break;
 
     case R_RISCV_LO12_I:

--- a/bfd/elfxx-riscv.c
+++ b/bfd/elfxx-riscv.c
@@ -890,7 +890,7 @@ static reloc_howto_type howto_table[] =
 	 "R_RISCV_CVPCREL_URS1",	/* name */
 	 FALSE,				/* partial_inplace */
 	 0,				/* src_mask */
-	 ENCODE_I1TYPE_UIMM (-1U),	/* dst_mask */
+	 ENCODE_CV_HWLP_UIMM5 (-1U),	/* dst_mask */
 	 TRUE),				/* pcrel_offset */
 };
 

--- a/gas/ChangeLog.COREV
+++ b/gas/ChangeLog.COREV
@@ -1,3 +1,11 @@
+2020-11-10  Mary Bennett  <mary.bennett@embecosm.com>
+
+	* config/tc-riscv.c (validate_riscv_insn): Renamed macros for clarity -
+	ENCODE_I1TYPE_UIMM -> ENCODE_CV_HWLP_UIMM5
+	ENCODE_I1TYPE_LN   -> ENCODE_CV_HWLP_LN
+	* config/tc-riscv.c (md_apply_fix): Renamed macros for clarity -
+	ENCODE_I1TYPE_UIMM -> ENCODE_CV_HWLP_UIMM5
+
 2020-10-05  Mary Bennett <mary.bennett@embecosm.com>
 
 	* config/tc-riscv.c: Fixed issue arising from incorrect CORE-V

--- a/gas/config/tc-riscv.c
+++ b/gas/config/tc-riscv.c
@@ -963,7 +963,7 @@ validate_riscv_insn (const struct riscv_opcode *opc, int length)
       case 'd':
 	if (*p == 'i')
 	  {
-	    used_bits |= ENCODE_I1TYPE_LN(-1U);
+	    used_bits |= ENCODE_CV_HWLP_LN(-1U);
 	    ++p;
 	    break;
 	  }
@@ -993,7 +993,7 @@ validate_riscv_insn (const struct riscv_opcode *opc, int length)
 	  }
 	else if (*p == '2')
 	  {
-	    used_bits |= ENCODE_I1TYPE_UIMM(-1U); /* For loop I1 type pc rel displacement */
+	    used_bits |= ENCODE_CV_HWLP_UIMM5(-1U); /* For loop I1 type pc rel displacement */
 	    ++p; break;
 	  }
 	break;
@@ -3167,7 +3167,7 @@ md_apply_fix (fixS *fixP, valueT *valP, segT seg ATTRIBUTE_UNUSED)
 	  if (r == bfd_reloc_overflow)
 	    as_fatal (_("BFD_RELOC_RISCV_CVPCREL_URS1 Overflow: Disp=%d"),
 		      (int) delta);
-	  bfd_putl32 (bfd_getl32 (buf) | ENCODE_I1TYPE_UIMM (delta), buf);
+	  bfd_putl32 (bfd_getl32 (buf) | ENCODE_CV_HWLP_UIMM5 (delta), buf);
 	}
       break;
 

--- a/include/ChangeLog.COREV
+++ b/include/ChangeLog.COREV
@@ -1,3 +1,12 @@
+2020-11-10  Mary Bennett  <mary.bennett@embecosm.com>
+
+	* opcode/riscv.h (riscv_pred_succ): Renamed macros for clarity -
+	ENCODE_I1TYPE_UIMM -> ENCODE_CV_HWLP_UIMM5
+	ENCODE_I1TYPE_LN   -> ENCODE_CV_HWLP_LN
+	EXTRACT_I1TYPE_UIMM-> EXTRACT_CV_HWLP_UIMM5
+	EXTRACT_I1TYPE_LN  -> EXTRACT_CV_HWLP_LN
+	EXTRACT_ITYPE_UIMM -> EXTRACT_CV_HWLP_UIMM12
+
 2020-10-05  Mary Bennett <mary.bennett@embecosm.com>
 
 	* opcode/riscv-opc.h: Fixed incorrect masks for CORE-V hardware loop

--- a/include/opcode/riscv.h
+++ b/include/opcode/riscv.h
@@ -108,11 +108,11 @@ static const char * const riscv_pred_succ[16] =
   ((RV_X(x, 3, 3) << 1) | (RV_X(x, 11, 1) << 4) | (RV_X(x, 2, 1) << 5) | (RV_X(x, 7, 1) << 6) | (RV_X(x, 6, 1) << 7) | (RV_X(x, 9, 2) << 8) | (RV_X(x, 8, 1) << 10) | (-RV_X(x, 12, 1) << 11))
 
 /* CORE-V Specific.  */
-#define EXTRACT_I1TYPE_UIMM(x) \
+#define EXTRACT_CV_HWLP_UIMM5(x) \
   (RV_X(x, 15, 5))
-#define EXTRACT_I1TYPE_LN(x) \
+#define EXTRACT_CV_HWLP_LN(x) \
   (RV_X(x, 7, 1))
-#define EXTRACT_ITYPE_UIMM(x) \
+#define EXTRACT_CV_HWLP_UIMM12(x) \
   (RV_X(x, 20, 12))
 
 #define ENCODE_ITYPE_IMM(x) \
@@ -155,9 +155,9 @@ static const char * const riscv_pred_succ[16] =
   ((RV_X(x, 1, 3) << 3) | (RV_X(x, 4, 1) << 11) | (RV_X(x, 5, 1) << 2) | (RV_X(x, 6, 1) << 7) | (RV_X(x, 7, 1) << 6) | (RV_X(x, 8, 2) << 9) | (RV_X(x, 10, 1) << 8) | (RV_X(x, 11, 1) << 12))
 
 /* CORE-V Specific.  */
-#define ENCODE_I1TYPE_UIMM(x) \
+#define ENCODE_CV_HWLP_UIMM5(x) \
   (RV_X(x, 0, 5) << 15)
-#define ENCODE_I1TYPE_LN(x) \
+#define ENCODE_CV_HWLP_LN(x) \
   (RV_X(x, 0, 1) << 7)
 
 #define VALID_ITYPE_IMM(x) (EXTRACT_ITYPE_IMM(ENCODE_ITYPE_IMM(x)) == (x))

--- a/opcodes/ChangeLog.COREV
+++ b/opcodes/ChangeLog.COREV
@@ -1,3 +1,9 @@
+2020-11-10  Mary Bennett  <mary.bennett@embecosm.com>
+
+	* riscv-opc.c (print_insn_args): Renamed macros for clarity -
+	EXTRACT_I1TYPE_UIMM-> EXTRACT_CV_HWLP_UIMM5
+	EXTRACT_ITYPE_UIMM -> EXTRACT_CV_HWLP_UIMM12
+
 2020-10-08  Mary Bennett  <mary.bennett@embecosm.com>
 
 	* riscv-opc.c: Added support for corevhwlp.

--- a/opcodes/riscv-dis.c
+++ b/opcodes/riscv-dis.c
@@ -282,7 +282,7 @@ print_insn_args (const char *d, insn_t l, bfd_vma pc, disassemble_info *info)
             }
 	  else if (d[1] == '2')
 	    {
-	      info->target = (EXTRACT_I1TYPE_UIMM (l)<<1) + pc; ++d;
+	      info->target = (EXTRACT_CV_HWLP_UIMM5 (l)<<1) + pc; ++d;
 	      (*info->print_address_func) (info->target, info);
 	      break;
 	    }
@@ -326,7 +326,7 @@ print_insn_args (const char *d, insn_t l, bfd_vma pc, disassemble_info *info)
 	  if (d[1] == 'i')
 	    {
 	      ++d;
-	      print (info->stream, "%d", (int) EXTRACT_ITYPE_UIMM (l));
+	      print (info->stream, "%d", (int) EXTRACT_CV_HWLP_UIMM12 (l));
 	      break;
 	    }
 	  if (((l & MASK_ADDI) == MATCH_ADDI && rs1 != 0)


### PR DESCRIPTION
bfd/ChangeLog.COREV:

	* elfnn-riscv.c: Renamed EXTRACT and ENCODE macros.
	* elfxx-riscv.c: Likewise.

gas/ChangeLog.COREV:

	* config/tc-riscv.c: Renamed EXTRACT and ENCODE macros.

include/ChangeLog.COREV:

	* opcode/riscv.h: Renamed EXTRACT and ENCODE macros.

opcodes/ChangeLog.COREV:

	* riscv-dis.c: Renamed EXTRACT and ENCODE macros.

Signed-off-by: Mary Bennett <mary.bennett@embecosm.com>