### PR TITLE
Added new boundary tests & fixed boundary check bug in hwloop & mac

### DIFF
--- a/gas/ChangeLog.COREV
+++ b/gas/ChangeLog.COREV
@@ -1,3 +1,8 @@
+2020-11-19  Jessica Mills  <jessica.mills@embecosm.com>
+
+	* config/tc-riscv.c: Fixed bug in hardware loop operand boundary
+	checks (b1 and b2).
+
 2020-11-11  Jessica Mills  <jessica.mills@embecosm.com>
 
 	* config/tc-riscv.c: Added CORE-V multiply accumulate support.
@@ -18,7 +23,7 @@
 
 2020-09-10  Pietra Ferreira  <pietra.ferreira@embecosm.com>
 
-	* config/tc-riscv.c: Added CORE-V harware loop support.
+	* config/tc-riscv.c: Added CORE-V hardware loop support.
 	* config/tc-riscv.h: Likewise.
 	* doc/c-riscv.texi: Noted Xcorev as additional ISA extension
 	 for CORE-V.

--- a/gas/config/tc-riscv.c
+++ b/gas/config/tc-riscv.c
@@ -2410,7 +2410,7 @@ riscv_ip (char *str, struct riscv_cl_insn *ip, expressionS *imm_expr,
 		  if (imm_expr->X_op == O_constant)
 		    {
 		      if (imm_expr->X_add_number < 0 ||
-			  ((imm_expr->X_add_number>>1) > 0x0FFF))
+			  ((imm_expr->X_add_number>>1) > 0x07FF))
 			as_bad (_("%ld constant out of range for %s, range:[0, %d]"),
 				imm_expr->X_add_number, ip->insn_mo->name, 0xFFE);
 		      if ((imm_expr->X_add_number % 2) == 1)
@@ -2437,7 +2437,7 @@ riscv_ip (char *str, struct riscv_cl_insn *ip, expressionS *imm_expr,
 		  if (imm_expr->X_op == O_constant)
 		    {
 		      if (imm_expr->X_add_number < 0 ||
-			  ((imm_expr->X_add_number>>1) > 31))
+			  ((imm_expr->X_add_number>>1) > 0xF))
 			as_bad (_("%ld constant out of range for "
 				  "cv.setupi, range:[0, %d]"),
 				imm_expr->X_add_number, 0x1E);

--- a/gas/testsuite/ChangeLog.COREV
+++ b/gas/testsuite/ChangeLog.COREV
@@ -1,3 +1,40 @@
+2020-11-19  Jessica Mills  <jessica.mills@embecosm.com>
+
+	* cv-hwloop-16.d: Added new boundary test.
+	* cv-hwloop-16.l: Likewise.
+	* cv-hwloop-16.s: Likewise.
+	* cv-hwloop-17.d: Likewise.
+	* cv-hwloop-17.l: Likewise.
+	* cv-hwloop-17.s: Likewise.
+	* cv-hwloop-18.d: Likewise.
+	* cv-hwloop-18.l: Likewise.
+	* cv-hwloop-18.s: Likewise.
+	* cv-hwloop-19.d: Likewise.
+	* cv-hwloop-19.l: Likewise.
+	* cv-hwloop-19.s: Likewise.
+	* cv-hwloop-20.d: Likewise.
+	* cv-hwloop-20.l: Likewise.
+	* cv-hwloop-20.s: Likewise.
+	* cv-hwloop-21.d: Likewise.
+	* cv-hwloop-21.l: Likewise.
+	* cv-hwloop-21.s: Likewise.
+	* cv-hwloop-22.d: Likewise.
+	* cv-hwloop-22.l: Likewise.
+	* cv-hwloop-22.s: Likewise.
+	* cv-hwloop-23.d: Likewise.
+	* cv-hwloop-23.l: Likewise.
+	* cv-hwloop-23.s: Likewise.
+	* cv-hwloop-09.s: Fixed incorrect comment.
+	* cv-hwloop-10.s: Likewise.
+	* cv-mac-07.d: Added new boundary test.
+	* cv-mac-07.l: Likewise.
+	* cv-mac-07.s: Likewise.
+	* cv-mac-08.d: Likewise.
+	* cv-mac-08.l: Likewise.
+	* cv-mac-08.s: Likewise.
+	* cv-mac-05.l: Changed to non-boundary value.
+	* cv-mac-05.s: Likewise.
+
 2020-11-11  Jessica Mills  <jessica.mills@embecosm.com>
 
 	* gas/riscv/cv-mac-01.d: Added new test.

--- a/gas/testsuite/gas/riscv/cv-hwloop-10.s
+++ b/gas/testsuite/gas/riscv/cv-hwloop-10.s
@@ -1,3 +1,3 @@
-# Loop count must be positive integer in range:[0, 4094]
+# Loop count must be positive integer in range:[0, 4095]
 target:
 	cv.setupi 0, 9000, 4

--- a/gas/testsuite/gas/riscv/cv-hwloop-16.d
+++ b/gas/testsuite/gas/riscv/cv-hwloop-16.d
@@ -1,0 +1,3 @@
+#as: -march=rv32i_xcorevhwlp
+#source: cv-hwloop-16.s
+#error_output: cv-hwloop-16.l

--- a/gas/testsuite/gas/riscv/cv-hwloop-16.l
+++ b/gas/testsuite/gas/riscv/cv-hwloop-16.l
@@ -1,0 +1,2 @@
+.*: Assembler messages:
+.*: Error: -1 constant out of range for cv.starti, range:\[0, 4094\]

--- a/gas/testsuite/gas/riscv/cv-hwloop-16.s
+++ b/gas/testsuite/gas/riscv/cv-hwloop-16.s
@@ -1,0 +1,3 @@
+# Branch offset must be an even integer in range:[0, 4094]
+target:
+	cv.starti 0, -1

--- a/gas/testsuite/gas/riscv/cv-hwloop-17.d
+++ b/gas/testsuite/gas/riscv/cv-hwloop-17.d
@@ -1,0 +1,3 @@
+#as: -march=rv32i_xcorevhwlp
+#source: cv-hwloop-17.s
+#error_output: cv-hwloop-17.l

--- a/gas/testsuite/gas/riscv/cv-hwloop-17.l
+++ b/gas/testsuite/gas/riscv/cv-hwloop-17.l
@@ -1,0 +1,2 @@
+.*: Assembler messages:
+.*: Error: 4096 constant out of range for cv.starti, range:\[0, 4094\]

--- a/gas/testsuite/gas/riscv/cv-hwloop-17.s
+++ b/gas/testsuite/gas/riscv/cv-hwloop-17.s
@@ -1,0 +1,4 @@
+# Branch offset must be an even integer in range:[0, 4094]
+# 4096 is the upper boundary as 4095 truncates to 4094
+target:
+	cv.starti 0, 4096

--- a/gas/testsuite/gas/riscv/cv-hwloop-18.d
+++ b/gas/testsuite/gas/riscv/cv-hwloop-18.d
@@ -1,0 +1,3 @@
+#as: -march=rv32i_xcorevhwlp
+#source: cv-hwloop-18.s
+#error_output: cv-hwloop-18.l

--- a/gas/testsuite/gas/riscv/cv-hwloop-18.l
+++ b/gas/testsuite/gas/riscv/cv-hwloop-18.l
@@ -1,0 +1,2 @@
+.*: Assembler messages:
+.*: Error: -1 constant out of range for cv.setupi, range:\[0, 30\]

--- a/gas/testsuite/gas/riscv/cv-hwloop-18.s
+++ b/gas/testsuite/gas/riscv/cv-hwloop-18.s
@@ -1,0 +1,3 @@
+# Branch offset must be an even integer in range:[0, 30]
+target:
+	cv.setupi 0, 1056, -1

--- a/gas/testsuite/gas/riscv/cv-hwloop-19.d
+++ b/gas/testsuite/gas/riscv/cv-hwloop-19.d
@@ -1,0 +1,3 @@
+#as: -march=rv32i_xcorevhwlp
+#source: cv-hwloop-19.s
+#error_output: cv-hwloop-19.l

--- a/gas/testsuite/gas/riscv/cv-hwloop-19.l
+++ b/gas/testsuite/gas/riscv/cv-hwloop-19.l
@@ -1,0 +1,2 @@
+.*: Assembler messages:
+.*: Error: 32 constant out of range for cv.setupi, range:\[0, 30\]

--- a/gas/testsuite/gas/riscv/cv-hwloop-19.s
+++ b/gas/testsuite/gas/riscv/cv-hwloop-19.s
@@ -1,0 +1,4 @@
+# Branch offset must be an even integer in range:[0, 30]
+# 32 is the upper boundary as 31 truncates to 30
+target:
+	cv.setupi 0, 1056, 32

--- a/gas/testsuite/gas/riscv/cv-hwloop-20.d
+++ b/gas/testsuite/gas/riscv/cv-hwloop-20.d
@@ -1,0 +1,3 @@
+#as: -march=rv32i_xcorevhwlp
+#source: cv-hwloop-20.s
+#error_output: cv-hwloop-20.l

--- a/gas/testsuite/gas/riscv/cv-hwloop-20.l
+++ b/gas/testsuite/gas/riscv/cv-hwloop-20.l
@@ -1,0 +1,2 @@
+.*: Assembler messages:
+.*: Error: cv.starti loop number must be 0 or 1

--- a/gas/testsuite/gas/riscv/cv-hwloop-20.s
+++ b/gas/testsuite/gas/riscv/cv-hwloop-20.s
@@ -1,0 +1,3 @@
+# Loop number must be 0 or 1
+target:
+	cv.starti -1, 104

--- a/gas/testsuite/gas/riscv/cv-hwloop-21.d
+++ b/gas/testsuite/gas/riscv/cv-hwloop-21.d
@@ -1,0 +1,3 @@
+#as: -march=rv32i_xcorevhwlp
+#source: cv-hwloop-21.s
+#error_output: cv-hwloop-21.l

--- a/gas/testsuite/gas/riscv/cv-hwloop-21.l
+++ b/gas/testsuite/gas/riscv/cv-hwloop-21.l
@@ -1,0 +1,2 @@
+.*: Assembler messages:
+.*: Error: cv.starti loop number must be 0 or 1

--- a/gas/testsuite/gas/riscv/cv-hwloop-21.s
+++ b/gas/testsuite/gas/riscv/cv-hwloop-21.s
@@ -1,0 +1,3 @@
+# Loop number must be 0 or 1
+target:
+	cv.starti 2, 104

--- a/gas/testsuite/gas/riscv/cv-hwloop-22.d
+++ b/gas/testsuite/gas/riscv/cv-hwloop-22.d
@@ -1,0 +1,3 @@
+#as: -march=rv32i_xcorevhwlp
+#source: cv-hwloop-22.s
+#error_output: cv-hwloop-22.l

--- a/gas/testsuite/gas/riscv/cv-hwloop-22.l
+++ b/gas/testsuite/gas/riscv/cv-hwloop-22.l
@@ -1,0 +1,2 @@
+.*: Assembler messages:
+.*: Error: -1 constant out of range for cv.setupi, range:\[0, 4095\]

--- a/gas/testsuite/gas/riscv/cv-hwloop-22.s
+++ b/gas/testsuite/gas/riscv/cv-hwloop-22.s
@@ -1,0 +1,3 @@
+# Loop count must be posivite integer in range:[0, 4095]
+target:
+	cv.setupi 0, -1, 4

--- a/gas/testsuite/gas/riscv/cv-hwloop-23.d
+++ b/gas/testsuite/gas/riscv/cv-hwloop-23.d
@@ -1,0 +1,3 @@
+#as: -march=rv32i_xcorevhwlp
+#source: cv-hwloop-23.s
+#error_output: cv-hwloop-23.l

--- a/gas/testsuite/gas/riscv/cv-hwloop-23.l
+++ b/gas/testsuite/gas/riscv/cv-hwloop-23.l
@@ -1,0 +1,2 @@
+.*: Assembler messages:
+.*: Error: 4096 constant out of range for cv.setupi, range:\[0, 4095\]

--- a/gas/testsuite/gas/riscv/cv-hwloop-23.s
+++ b/gas/testsuite/gas/riscv/cv-hwloop-23.s
@@ -1,3 +1,3 @@
 # Loop count must be positive integer in range:[0, 4095]
 target:
-	cv.setupi 0, -900, 4
+	cv.setupi 0, 4096, 4

--- a/gas/testsuite/gas/riscv/cv-mac-05.l
+++ b/gas/testsuite/gas/riscv/cv-mac-05.l
@@ -1,2 +1,2 @@
 .*: Assembler messages:
-.*: Error: illegal operands `cv.mulsn t0,t1,t2,32'
+.*: Error: illegal operands `cv.mulsn t0,t1,t2,300'

--- a/gas/testsuite/gas/riscv/cv-mac-07.d
+++ b/gas/testsuite/gas/riscv/cv-mac-07.d
@@ -1,0 +1,3 @@
+#as: -march=rv32i_xcorevmac
+#source: cv-mac-07.s
+#error_output: cv-mac-07.l

--- a/gas/testsuite/gas/riscv/cv-mac-07.l
+++ b/gas/testsuite/gas/riscv/cv-mac-07.l
@@ -1,0 +1,2 @@
+.*: Assembler messages:
+.*: Error: illegal operands `cv.mulsn t0,t1,t2,-1'

--- a/gas/testsuite/gas/riscv/cv-mac-07.s
+++ b/gas/testsuite/gas/riscv/cv-mac-07.s
@@ -1,3 +1,3 @@
 # Immediate value must be in range [0, 31]
 target:
-	cv.mulsn t0, t1, t2, 300
+	cv.mulsn t0, t1, t2, -1

--- a/gas/testsuite/gas/riscv/cv-mac-08.d
+++ b/gas/testsuite/gas/riscv/cv-mac-08.d
@@ -1,0 +1,3 @@
+#as: -march=rv32i_xcorevmac
+#source: cv-mac-08.s
+#error_output: cv-mac-08.l

--- a/gas/testsuite/gas/riscv/cv-mac-08.l
+++ b/gas/testsuite/gas/riscv/cv-mac-08.l
@@ -1,0 +1,2 @@
+.*: Assembler messages:
+.*: Error: illegal operands `cv.mulsn t0,t1,t2,32'

--- a/gas/testsuite/gas/riscv/cv-mac-08.s
+++ b/gas/testsuite/gas/riscv/cv-mac-08.s
@@ -1,3 +1,3 @@
 # Immediate value must be in range [0, 31]
 target:
-	cv.mulsn t0, t1, t2, 300
+	cv.mulsn t0, t1, t2, 32


### PR DESCRIPTION
            Also: 1) clean up a couple of inaccurate comments in two earlier HW Loop
            tests; and 2) change an existing MAC test to use a non-boundary value.

  gas/ChangeLog.COREV:
    
            * config/tc-riscv.c: Fixed bug in hardware loop operand
            boundary checks (b1 and b2).
    
    gas/testsuite/ChangeLog.COREV:
    
            * cv-hwloop-16.d: Added new boundary test.
            * cv-hwloop-16.l: Likewise.
            * cv-hwloop-16.s: Likewise.
            * cv-hwloop-17.d: Likewise.
            * cv-hwloop-17.l: Likewise.
            * cv-hwloop-17.s: Likewise.
            * cv-hwloop-18.d: Likewise.
            * cv-hwloop-18.l: Likewise.
            * cv-hwloop-18.s: Likewise.
            * cv-hwloop-19.d: Likewise.
            * cv-hwloop-19.l: Likewise.
            * cv-hwloop-19.s: Likewise.
            * cv-hwloop-20.d: Likewise.
            * cv-hwloop-20.l: Likewise.
            * cv-hwloop-20.s: Likewise.
            * cv-hwloop-21.d: Likewise.
            * cv-hwloop-21.l: Likewise.
            * cv-hwloop-21.s: Likewise.
            * cv-hwloop-22.d: Likewise.
            * cv-hwloop-22.l: Likewise.
            * cv-hwloop-22.s: Likewise.
            * cv-hwloop-23.d: Likewise.
            * cv-hwloop-23.l: Likewise.
            * cv-hwloop-23.s: Likewise.
            * cv-hwloop-09.s: Fixed incorrect comment.
            * cv-hwloop-10.s: Likewise.
            * cv-mac-07.d: Added new boundary test.
            * cv-mac-07.l: Likewise.
            * cv-mac-07.s: Likewise.
            * cv-mac-08.d: Likewise.
            * cv-mac-08.l: Likewise.
            * cv-mac-08.s: Likewise.
            * cv-mac-05.l: Changed to non-boundary value.
            * cv-mac-05.s: Likewise.
    
    Signed-off-by: Jessica Mills <jessica.mills@embecosm.com>
