### PR TITLE
Added CORE-V extension subsets ISA options to gas documentation

### DIFF
--- a/gas/ChangeLog.COREV
+++ b/gas/ChangeLog.COREV
@@ -1,3 +1,8 @@
+2020-11-24  Jessica Mills  <jessica.mills@embecosm.com>
+
+	* doc/c-riscv.texi: Added details on CORE-V hardware loop,
+	multiply-accumulate and general ALU ops ISA options.
+
 2020-11-20  Pietra Ferreira  <pietra.ferreira@embecosm.com>
 
 	* config/tc-riscv.c: Added CORE-V general ALU operations support.

--- a/gas/doc/c-riscv.texi
+++ b/gas/doc/c-riscv.texi
@@ -46,7 +46,16 @@ If this option and the architecture attributes aren't set, then assembler
 will check the default configure setting --with-arch=ISA.
 
 For the CORE-V variant of the assembler, an additional ISA option @samp{Xcorev}
-is provided to enable the CORE-V extensions.
+is provided to enable all CORE-V extensions. To enable only a subset of the CORE-V
+extensions, the following additional ISA options are provided:
+@itemize @bullet
+@item
+hardware loop: @samp{Xcorevhwlp}
+@item
+multiply-accumulate: @samp{Xcorevmac}
+@item
+general ALU operations: @samp{Xcorevalu}
+@end itemize
 
 @cindex @samp{-misa-spec=ISAspec} option, RISC-V
 @item -misa-spec=ISAspec


### PR DESCRIPTION
gas/ChangeLog.COREV:

	* doc/c-riscv.texi: Added details on CORE-V hardware loop,
	multiply-accumulate and general ALU ops ISA options.

Signed-off-by: Jessica Mills <jessica.mills@embecosm.com>