### PR TITLE
Correct CORE-V ChangeLogs in line with GNU standards

### DIFF
--- a/bfd/ChangeLog.COREV
+++ b/bfd/ChangeLog.COREV
@@ -10,8 +10,12 @@
 
 2020-09-10  Pietra Ferreira  <pietra.ferreira@embecosm.com>
 
-	* bfd-in2.h: Added CORE-V hardware loop specific relocations.
-	* elfnn-riscv.c: Added relocations for CORE-V hardware loop.
-	* elfxx-riscv.c: Added relocations and amend howto lookup.
-	* bfd/riscv.c: Added BFD_RELOC_RISCV_CVPCREL_UI12 and
-	BFD_RELOC_RISCV_CVPCREL_URS1.
+	* bfd-in2.h: Regenerated.
+	* elfnn-riscv.c (perform_relocation, riscv_elf_relocate_section):
+	Add hardware loop specific relocations - BFD_RELOC_RISCV_CVPCREL_UI12
+	and BFD_RELOC_RISCV_CVPCREL_URS1.
+	* elfxx-riscv.c (howto_table, howto_table): Add hardware loop
+	specific relocations.
+	(riscv_reloc_name_lookup, riscv_elf_rtype_to_howto)
+	(riscv_reloc_type_lookup): Amend lookup to search relocation numbers
+	not in ascending order.

--- a/gas/ChangeLog.COREV
+++ b/gas/ChangeLog.COREV
@@ -1,20 +1,24 @@
 2020-11-24  Jessica Mills  <jessica.mills@embecosm.com>
 
-	* doc/c-riscv.texi: Added details on CORE-V hardware loop,
+	* doc/c-riscv.texi: Add details on hardware loop,
 	multiply-accumulate and general ALU ops ISA options.
 
 2020-11-20  Pietra Ferreira  <pietra.ferreira@embecosm.com>
 
-	* config/tc-riscv.c: Added CORE-V general ALU operations support.
+	* config/tc-riscv.c (riscv_multi_subset_supports): Add general
+	ALU ops instruction class.
+	(validate_riscv_insn, riscv_ip): Add general ALU ops operands.
 
 2020-11-19  Jessica Mills  <jessica.mills@embecosm.com>
 
-	* config/tc-riscv.c: Fixed bug in hardware loop operand boundary
-	checks (b1 and b2).
+	* config/tc-riscv.c (riscv_ip): Bug fix in hardware loop operand
+	boundary checks - b1 and b2.
 
 2020-11-11  Jessica Mills  <jessica.mills@embecosm.com>
 
-	* config/tc-riscv.c: Added CORE-V multiply accumulate support.
+	* config/tc-riscv.c (riscv_multi_subset_supports): Add multiply
+	accumulate instruction class.
+	(validate_riscv_insn, riscv_ip): Add multiply accumulate operands.
 
 2020-11-10  Mary Bennett  <mary.bennett@embecosm.com>
 
@@ -26,13 +30,18 @@
 
 2020-10-05  Mary Bennett  <mary.bennett@embecosm.com>
 
-	* config/tc-riscv.c: Fixed issue arising from incorrect CORE-V
-	hardware loop masks and added support for xcorevhwlp and new
-	error messages.
+	* config/tc-riscv.c (riscv_multi_subset_supports): Replace general
+	CORE-V instruction class with hardware loop instruction class.
+	(validate_riscv_insn): Fix issue arising from incorrect hardware loop
+	masks.
+	(riscv_ip): Improve error messages.
 
 2020-09-10  Pietra Ferreira  <pietra.ferreira@embecosm.com>
 
-	* config/tc-riscv.c: Added CORE-V hardware loop support.
-	* config/tc-riscv.h: Likewise.
+	* config/tc-riscv.c (riscv_multi_subset_supports): Add CORE-V
+	instruction class.
+	(validate_riscv_insn, riscv_ip): Add hardware loop operands.
+	(md_apply_fix): Add hardware loop relocations
+	BFD_RELOC_RISCV_CVPCREL_UI12 and BFD_RELOC_RISCV_CVPCREL_URS1.
 	* doc/c-riscv.texi: Noted Xcorev as additional ISA extension
 	 for CORE-V.

--- a/include/ChangeLog.COREV
+++ b/include/ChangeLog.COREV
@@ -1,26 +1,25 @@
 2021-01-11  Jessica Mills  <jessica.mills@embecosm.com>
 
-	* opcode/riscv-opc.h: Removed obsolete matches and renamed mask
-	accordingly -
-	MATCH_MACS:	Removed.
-	MATCH_MACHHS:	Removed.
-	MATCH_MACU:	Removed.
-	MATCH_MACHHU:	Removed.
-	MASK_MULMAC ->	MASK_MULSH
+	* opcode/riscv-opc.h: (MATCH_MACS, MATCH_MACHHS, MATCH_MACU)
+	(MATCH_MACHHU): Remove obsolete matches.
+	(MASK_MULMAC): Rename mask as MASK_MULSH.
 
 2020-11-20  Mary Bennett  <mary.bennett@embecosm.com>
 
-	* opcode/riscv-opc.h: Added CORE-V general ALU operations support.
-	* opcode/riscv.h: Likewise.
+	* opcode/riscv-opc.h: Add general ALU ops masks and matches.
+	* opcode/riscv.h (EXTRACT_CV_ALU_UIMM5, ENCODE_CV_ALU_UIMM5): Add
+	macros for general ALU ops 5-bit unsigned immediate.
 
 2020-11-11  Jessica Mills  <jessica.mills@embecosm.com>
 
-	* opcode/riscv-opc.h: Added CORE-V multiply accumulate support.
-	* opcode/riscv.h: Likewise.
+	* opcode/riscv-opc.h: Add multiply accumulate masks and
+	matches.
+	* opcode/riscv.h (EXTRACT_CV_MAC_UIMM5, ENCODE_CV_MAC_UIMM5): Add
+	macros for multiply accumulate 5-bit unsigned immediate.
 
 2020-11-10  Mary Bennett  <mary.bennett@embecosm.com>
 
-	* opcode/riscv.h (riscv_pred_succ): Renamed macros for clarity -
+	* opcode/riscv.h (riscv_pred_succ): Rename macros for clarity -
 	ENCODE_I1TYPE_UIMM -> ENCODE_CV_HWLP_UIMM5
 	ENCODE_I1TYPE_LN   -> ENCODE_CV_HWLP_LN
 	EXTRACT_I1TYPE_UIMM-> EXTRACT_CV_HWLP_UIMM5
@@ -29,13 +28,17 @@
 
 2020-10-05  Mary Bennett <mary.bennett@embecosm.com>
 
-	* opcode/riscv-opc.h: Fixed incorrect masks for CORE-V hardware loop
+	* opcode/riscv-opc.h: Fix incorrect masks for hardware loop
 	instructions.
-	* opcode/riscv.h: Added support for xcorevhwlp.
+	* opcode/riscv.h (riscv_insn_class): Add hardware loop instruction
+	class.
 
 2020-09-10  Pietra Ferreira  <pietra.ferreira@embecosm.com>
 
-	* elf/riscv.h: Added CORE-V hardware loop specific relocations.
-	* opcode/riscv.h: Added CORE-V hardware loop specific masks and
-	CORE-V instruction class. Added macros for unsigned I type
-	immediate and loop number.
+	* elf/riscv.h: Add hardware loop specific relocations -
+	R_RISCV_CVPCREL_UI12 and R_RISCV_CVPCREL_URS1.
+	* opcode/riscv.h: Add hardware loop masks.
+	(riscv_insn_class): Add CORE-V instruction class. 
+	(EXTRACT_I1TYPE_UIMM, EXTRACT_I1TYPE_LN, EXTRACT_ITYPE_UIMM)
+	(ENCODE_I1TYPE_UIMM, ENCODE_I1TYPE_LN): Add macros for unsigned I type
+	immediates and loop number.

--- a/ld/ChangeLog.COREV
+++ b/ld/ChangeLog.COREV
@@ -1,3 +1,0 @@
-2020-09-10  Pietra Ferreira  <pietra.ferreira@embecosm.com>
-
-	* emultempl/riscvelf.em: Added initial CORE-V support.

--- a/opcodes/ChangeLog.COREV
+++ b/opcodes/ChangeLog.COREV
@@ -1,32 +1,32 @@
 2021-01-11  Jessica Mills  <jessica.mills@embecosm.com>
 
-	* riscv-opc.c: Removed obsolete instructions -
-	cv.macs:	Removed.
-	cv.machhs:	Removed.
-	cv.macu:	Removed.
-	cv.machhu:	Removed.
+	* riscv-opc.h (MATCH_MACS, MATCH_MACHHS, MATCH_MACU)
+	(MATCH_MACHHU): Remove obsolete matches.
+	(MASK_MULMAC): Rename mask as MASK_MULSH
 
 2020-11-20  Pietra Ferreira  <pietra.ferreira@embecosm.com>
 
-	* riscv-dis.c: Added CORE-V general ALU operations support.
-	* riscv-opc.c: Likewise.
+	* riscv-dis.c (print_insn_args): Add general ALU ops operands.
+	* riscv-opc.c (riscv_opcodes): Add general ALU ops opcodes.
 
 2020-11-11  Jessica Mills  <jessica.mills@embecosm.com>
 
-	* riscv-dis.c: Added CORE-V multiply accumulate support.
-	* riscv-opc.c: Likewise.
+	* riscv-dis.c (print_insn_args): Add multiply accumulate operands.
+	* riscv-opc.c (riscv_opcodes): Add multiply accumulate opcodes.
 
 2020-11-10  Mary Bennett  <mary.bennett@embecosm.com>
 
-	* riscv-opc.c (print_insn_args): Renamed macros for clarity -
+	* riscv-opc.c (print_insn_args): Rename macros for clarity -
 	EXTRACT_I1TYPE_UIMM-> EXTRACT_CV_HWLP_UIMM5
 	EXTRACT_ITYPE_UIMM -> EXTRACT_CV_HWLP_UIMM12
 
 2020-10-08  Mary Bennett  <mary.bennett@embecosm.com>
 
-	* riscv-opc.c: Added support for corevhwlp.
+	* riscv-opc.c (riscv_opcodes): Amend instruction class for hardware
+	loop opcodes -
+	INSN_CLASS_COREV -> INSN_CLASS_COREV_HWLP
 
 2020-09-10  Pietra Ferreira  <pietra.ferreira@embecosm.com>
 
-	* riscv-dis.c: Added CORE-V hardware loop support.
-	* riscv-opc.c: Likewise.
+	* riscv-dis.c (print_insn_args): Add hardware loop operands.
+	* riscv-opc.c (riscv_opcodes): Add hardware loop opcodes.


### PR DESCRIPTION
Files changed:

	* bfd/ChangeLog.COREV: Correct in line with GNU standards.
	* gas/ChangeLog.COREV: Likewise.
	* include/ChangeLog.COREV: Likewise.
	* opcodes/ChangeLog.COREV: Likewise.
	* ld/ChangeLog.COREV: Removed.

Signed-off-by: Jessica Mills <jessica.mills@embecosm.com>