### PR TITLE
Remove unnecessary overflow check for BFD_RELOC_RISCV_CVPCREL_(UI12 & URS1)

### DIFF
--- a/gas/ChangeLog.COREV
+++ b/gas/ChangeLog.COREV
@@ -1,3 +1,8 @@
+2021-01-27  Jessica Mills  <jessica.mills@embecosm.com>
+
+	* config/tc-riscv.c (md_apply_fix): Remove unnecessary overflow check
+	for BFD_RELOC_RISCV_CVPCREL_UI12 & BFD_RELOC_RISCV_CVPCREL_URS1.
+
 2020-11-24  Jessica Mills  <jessica.mills@embecosm.com>
 
 	* doc/c-riscv.texi: Add details on hardware loop,

--- a/gas/config/tc-riscv.c
+++ b/gas/config/tc-riscv.c
@@ -3176,16 +3176,13 @@ md_apply_fix (fixS *fixP, valueT *valP, segT seg ATTRIBUTE_UNUSED)
 	  reloc_howto_type *howto;
 	  bfd_reloc_status_type r;
 
-	  /* This reloc is local, always resolvable, S_GET_VALUE returns an
-	     error in case not resolvable */
+	  /* Fill in a tentative value to improve objdump readability.  */
 	  howto = bfd_reloc_type_lookup (stdoutput, fixP->fx_r_type);
 	  bfd_vma target = S_GET_VALUE (fixP->fx_addsy) + *valP;
 	  bfd_vma delta = (target - md_pcrel_from (fixP)) >> howto->rightshift;
 	  r = bfd_check_overflow (howto->complain_on_overflow, 12, 0, 32, delta);
-	  if (r == bfd_reloc_overflow)
-	    as_fatal (_("BFD_RELOC_RISCV_CVPCREL_UI12 Overflow: Disp=%d"),
-		      (int) delta);
-	  bfd_putl32 (bfd_getl32 (buf) | ENCODE_ITYPE_IMM (delta), buf);
+	  if (r != bfd_reloc_overflow)
+	    bfd_putl32 (bfd_getl32 (buf) | ENCODE_ITYPE_IMM (delta), buf);
 	}
       break;
 
@@ -3195,16 +3192,13 @@ md_apply_fix (fixS *fixP, valueT *valP, segT seg ATTRIBUTE_UNUSED)
 	  reloc_howto_type *howto;
 	  bfd_reloc_status_type r;
 
-	  /* This reloc is local, always resolvable, S_GET_VALUE returns an
-	  error in case not resolvable */
+	  /* Fill in a tentative value to improve objdump readability.  */
 	  howto = bfd_reloc_type_lookup (stdoutput, fixP->fx_r_type);
 	  bfd_vma target = S_GET_VALUE (fixP->fx_addsy) + *valP;
 	  bfd_vma delta = (target - md_pcrel_from (fixP)) >> howto->rightshift;
 	  r = bfd_check_overflow (howto->complain_on_overflow, 5, 0, 32, delta);
-	  if (r == bfd_reloc_overflow)
-	    as_fatal (_("BFD_RELOC_RISCV_CVPCREL_URS1 Overflow: Disp=%d"),
-		      (int) delta);
-	  bfd_putl32 (bfd_getl32 (buf) | ENCODE_CV_HWLP_UIMM5 (delta), buf);
+	  if (r != bfd_reloc_overflow)
+	    bfd_putl32 (bfd_getl32 (buf) | ENCODE_CV_HWLP_UIMM5 (delta), buf);
 	}
       break;
 

--- a/gas/testsuite/ChangeLog.COREV
+++ b/gas/testsuite/ChangeLog.COREV
@@ -1,3 +1,8 @@
+2021-01-27  Jessica Mills  <jessica.mills@embecosm.com>
+
+	* gas/riscv/cv-hwlp-fail-operand-07.l: Remove obsolete
+	BFD_RELOC_RISCV_CVPCREL_UI12 overflow error message.
+
 2021-01-15  Jessica Mills  <jessica.mills@embecosm.com>
 
 	* gas/riscv/cv-mac-fail-march.d: Added new test.

--- a/gas/testsuite/gas/riscv/cv-hwlp-fail-operand-07.l
+++ b/gas/testsuite/gas/riscv/cv-hwlp-fail-operand-07.l
@@ -2,4 +2,3 @@
 .*: Error: cv.starti immediate value must be a constant or label
 .*: Error: cv.endi immediate value must be a constant or label
 .*: Error: cv.setup immediate value must be a constant or label
-.*: Fatal error: BFD_RELOC_RISCV_CVPCREL_UI12 Overflow: Disp=-2


### PR DESCRIPTION

gas/ChangeLog.COREV:

	* config/tc-riscv.c (md_apply_fix): Remove unnecessary overflow check
	for BFD_RELOC_RISCV_CVPCREL_UI12 & BFD_RELOC_RISCV_CVPCREL_URS1.

gas/testsuite/ChangeLog.COREV:

	* gas/riscv/cv-hwlp-fail-operand-07.l: Remove obsolete
	BFD_RELOC_RISCV_CVPCREL_UI12 overflow error message.

Signed-off-by: Jessica Mills <jessica.mills@embecosm.com>