### PR TITLE
Add '0x' prefix for CORE-V hwlp immediate offsets

### DIFF
--- a/gas/testsuite/ChangeLog.COREV
+++ b/gas/testsuite/ChangeLog.COREV
@@ -1,3 +1,17 @@
+2021-02-17  Jessica Mills  <jessica.mills@embecosm.com>
+
+	* gas/riscv/cv-hwlp-endi.d: Amend to include '0x' prefix for offset immediate.
+	* gas/riscv/cv-hwlp-march-rv32i-xcorev.d: Likewise.
+	* gas/riscv/cv-hwlp-setup.d: Likewise.
+	* gas/riscv/cv-hwlp-setupi.d: Likewise.
+	* gas/riscv/cv-hwlp-starti.d: Likewise.
+	* gas/riscv/cv-hwlp-endi.s: Amend to use hexadecimal immediate value
+	where objdump outputs hexadecimal value. 
+	* gas/riscv/cv-hwlp-march-rv32i-xcorev.s: Likewise.
+	* gas/riscv/cv-hwlp-setup.s: Likewise.
+	* gas/riscv/cv-hwlp-setupi.s: Likewise.
+	* gas/riscv/cv-hwlp-starti.s: Likewise.
+
 2021-01-27  Jessica Mills  <jessica.mills@embecosm.com>
 
 	* gas/riscv/cv-hwlp-fail-operand-07.l: Remove obsolete

--- a/gas/testsuite/gas/riscv/cv-hwlp-endi.d
+++ b/gas/testsuite/gas/riscv/cv-hwlp-endi.d
@@ -7,6 +7,6 @@
 Disassembly of section .text:
 
 0+000 <target>:
-[ 	]+0:[ 	]+0000107b[ 	]+cv.endi[ 	]+0,0 <target>
-[ 	]+4:[ 	]+210010fb[ 	]+cv.endi[ 	]+1,424 +<target\+0x424>
-[ 	]+8:[ 	]+7ff0107b[ 	]+cv.endi[ 	]+0,1006 +<target\+0x1006>
+[ 	]+0:[ 	]+0000107b[ 	]+cv.endi[ 	]+0,0x0 <target>
+[ 	]+4:[ 	]+210010fb[ 	]+cv.endi[ 	]+1,0x424 +<target\+0x424>
+[ 	]+8:[ 	]+7ff0107b[ 	]+cv.endi[ 	]+0,0x1006 +<target\+0x1006>

--- a/gas/testsuite/gas/riscv/cv-hwlp-endi.s
+++ b/gas/testsuite/gas/riscv/cv-hwlp-endi.s
@@ -1,4 +1,4 @@
 target:
 	cv.endi 0, 0
-	cv.endi 1, 1056
-	cv.endi 0, 4094
+	cv.endi 1, 0x420
+	cv.endi 0, 0xffe

--- a/gas/testsuite/gas/riscv/cv-hwlp-march-rv32i-xcorev.d
+++ b/gas/testsuite/gas/riscv/cv-hwlp-march-rv32i-xcorev.d
@@ -7,9 +7,9 @@
 Disassembly of section .text:
 
 0+000 <target>:
-[ 	]+0:[ 	]+0a0000fb[ 	]+cv.starti[ 	]+1,140 +<target\+0x140>
-[ 	]+4:[ 	]+210010fb[ 	]+cv.endi[ 	]+1,424 +<target\+0x424>
-[ 	]+8:[ 	]+1e8350fb[ 	]+cv.setupi[ 	]+1,488,14 <target\+0x14>
-[ 	]+c:[ 	]+0f4f40fb[ 	]+cv.setup[ 	]+1,t5,1f4 <target\+0x1f4>
+[ 	]+0:[ 	]+0a0000fb[ 	]+cv.starti[ 	]+1,0x140 +<target\+0x140>
+[ 	]+4:[ 	]+210010fb[ 	]+cv.endi[ 	]+1,0x424 +<target\+0x424>
+[ 	]+8:[ 	]+1e8350fb[ 	]+cv.setupi[ 	]+1,488,0x14 <target\+0x14>
+[ 	]+c:[ 	]+0f4f40fb[ 	]+cv.setup[ 	]+1,t5,0x1f4 <target\+0x1f4>
 [ 	]+10:[ 	]+0005a0fb[ 	]+cv.count[ 	]+1,a1
 [ 	]+14:[ 	]+791030fb[ 	]+cv.counti[ 	]+1,1937

--- a/gas/testsuite/gas/riscv/cv-hwlp-march-rv32i-xcorev.s
+++ b/gas/testsuite/gas/riscv/cv-hwlp-march-rv32i-xcorev.s
@@ -1,8 +1,8 @@
 # xcorev march option works for all CORE-V hwloop extensions
 target:
-	cv.starti 1, 320
-        cv.endi   1, 1056
-        cv.setupi 1, 488, 12
-        cv.setup  1, t5, 488
-        cv.count  1, a1
-        cv.counti 1, 1937
+	cv.starti 1, 0x140
+	cv.endi   1, 0x420
+	cv.setupi 1, 488, 0xc
+	cv.setup  1, t5, 0x1e8
+	cv.count  1, a1
+	cv.counti 1, 1937

--- a/gas/testsuite/gas/riscv/cv-hwlp-setup.d
+++ b/gas/testsuite/gas/riscv/cv-hwlp-setup.d
@@ -7,6 +7,6 @@
 Disassembly of section .text:
 
 0+000 <target>:
-[ 	]+0:[ 	]+0002c07b[ 	]+cv.setup[ 	]+0,t0,0 <target>
-[ 	]+4:[ 	]+0f4f40fb[ 	]+cv.setup[ 	]+1,t5,1ec <target\+0x1ec>
-[ 	]+8:[ 	]+7ff5407b[ 	]+cv.setup[ 	]+0,a0,1006 <target\+0x1006>
+[ 	]+0:[ 	]+0002c07b[ 	]+cv.setup[ 	]+0,t0,0x0 <target>
+[ 	]+4:[ 	]+0f4f40fb[ 	]+cv.setup[ 	]+1,t5,0x1ec <target\+0x1ec>
+[ 	]+8:[ 	]+7ff5407b[ 	]+cv.setup[ 	]+0,a0,0x1006 <target\+0x1006>

--- a/gas/testsuite/gas/riscv/cv-hwlp-setup.s
+++ b/gas/testsuite/gas/riscv/cv-hwlp-setup.s
@@ -1,4 +1,4 @@
 target:
 	cv.setup 0, t0, 0
-	cv.setup 1, t5, 488
-	cv.setup 0, a0, 4094
+	cv.setup 1, t5, 0x1e8
+	cv.setup 0, a0, 0xffe

--- a/gas/testsuite/gas/riscv/cv-hwlp-setupi.d
+++ b/gas/testsuite/gas/riscv/cv-hwlp-setupi.d
@@ -7,6 +7,6 @@
 Disassembly of section .text:
 
 0+000 <target>:
-[ 	]+0:[ 	]+0000507b[ 	]+cv.setupi[ 	]+0,0,0 <target>
-[ 	]+4:[ 	]+1e8350fb[ 	]+cv.setupi[ 	]+1,488,10 <target\+0x10>
-[ 	]+8:[ 	]+fff7d07b[ 	]+cv.setupi[ 	]+0,4095,26 <target\+0x26>
+[ 	]+0:[ 	]+0000507b[ 	]+cv.setupi[ 	]+0,0,0x0 <target>
+[ 	]+4:[ 	]+1e8350fb[ 	]+cv.setupi[ 	]+1,488,0x10 <target\+0x10>
+[ 	]+8:[ 	]+fff7d07b[ 	]+cv.setupi[ 	]+0,4095,0x26 <target\+0x26>

--- a/gas/testsuite/gas/riscv/cv-hwlp-setupi.s
+++ b/gas/testsuite/gas/riscv/cv-hwlp-setupi.s
@@ -1,4 +1,4 @@
 target:
 	cv.setupi 0, 0, 0
-	cv.setupi 1, 488, 12
-	cv.setupi 0, 4095, 30
+	cv.setupi 1, 488, 0xc
+	cv.setupi 0, 4095, 0x1e

--- a/gas/testsuite/gas/riscv/cv-hwlp-starti.d
+++ b/gas/testsuite/gas/riscv/cv-hwlp-starti.d
@@ -7,6 +7,6 @@
 Disassembly of section .text:
 
 0+000 <target>:
-[ 	]+0:[ 	]+0000007b[ 	]+cv.starti[ 	]+0,0 <target>
-[ 	]+4:[ 	]+5e6000fb[ 	]+cv.starti[ 	]+1,bd0 +<target\+0xbd0>
-[ 	]+8:[ 	]+7ff0007b[ 	]+cv.starti[ 	]+0,1006 +<target\+0x1006>
+[ 	]+0:[ 	]+0000007b[ 	]+cv.starti[ 	]+0,0x0 <target>
+[ 	]+4:[ 	]+5e6000fb[ 	]+cv.starti[ 	]+1,0xbd0 +<target\+0xbd0>
+[ 	]+8:[ 	]+7ff0007b[ 	]+cv.starti[ 	]+0,0x1006 +<target\+0x1006>

--- a/gas/testsuite/gas/riscv/cv-hwlp-starti.s
+++ b/gas/testsuite/gas/riscv/cv-hwlp-starti.s
@@ -1,4 +1,4 @@
 target:
 	cv.starti 0, 0
-	cv.starti 1, 3020
-	cv.starti 0, 4094
+	cv.starti 1, 0xbcc
+	cv.starti 0, 0xffe

--- a/opcodes/ChangeLog.COREV
+++ b/opcodes/ChangeLog.COREV
@@ -1,3 +1,8 @@
+2021-02-17  Jessica Mills  <jessica.mills@embecosm.com>
+
+	* riscv-dis.c (print_insn_args): Add '0x' prefix for hexadecimal
+	immediate offsets b1 and b2.
+
 2021-01-11  Jessica Mills  <jessica.mills@embecosm.com>
 
 	* riscv-opc.h (MATCH_MACS, MATCH_MACHHS, MATCH_MACU)

--- a/opcodes/riscv-dis.c
+++ b/opcodes/riscv-dis.c
@@ -277,12 +277,14 @@ print_insn_args (const char *d, insn_t l, bfd_vma pc, disassemble_info *info)
 	  if (d[1] == '1')
 	    {
 	      info->target = (EXTRACT_ITYPE_IMM (l)<<1) + pc; ++d;
+	      print (info->stream, "0x");
 	      (*info->print_address_func) (info->target, info);
 	      break;
-            }
+	    }
 	  else if (d[1] == '2')
 	    {
 	      info->target = (EXTRACT_CV_HWLP_UIMM5 (l)<<1) + pc; ++d;
+	      print (info->stream, "0x");
 	      (*info->print_address_func) (info->target, info);
 	      break;
 	    }


### PR DESCRIPTION
gas/testsuite/ChangeLog.COREV:

	* gas/riscv/cv-hwlp-endi.d: Amend to include '0x' prefix for offset immediate.
	* gas/riscv/cv-hwlp-march-rv32i-xcorev.d: Likewise.
	* gas/riscv/cv-hwlp-setup.d: Likewise.
	* gas/riscv/cv-hwlp-setupi.d: Likewise.
	* gas/riscv/cv-hwlp-starti.d: Likewise.
	* gas/riscv/cv-hwlp-endi.s: Amend to use hexadecimal immediate value where objdump outputs hexadecimal value.
	* gas/riscv/cv-hwlp-march-rv32i-xcorev.s: Likewise.
	* gas/riscv/cv-hwlp-setup.s: Likewise.
	* gas/riscv/cv-hwlp-setupi.s: Likewise.
	* gas/riscv/cv-hwlp-starti.s: Likewise.

opcodes/ChangeLog.COREV:

	* riscv-dis.c (print_insn_args): Add '0x' prefix for hexadecimal
	immediate offsets b1 and b2.

Signed-off-by: Jessica Mills <jessica.mills@embecosm.com>