### PR TITLE
Fix whitespace inconsistencies

### DIFF
--- a/gas/testsuite/ChangeLog.COREV
+++ b/gas/testsuite/ChangeLog.COREV
@@ -1,3 +1,8 @@
+2021-02-19  Jessica Mills  <jessica.mills@embecosm.com>
+
+	* gas/riscv/cv-hwlp-march-rv32i-xcorev.s: Fix whitespace
+	inconsistencies.
+
 2021-01-27  Jessica Mills  <jessica.mills@embecosm.com>
 
 	* gas/riscv/cv-hwlp-fail-operand-07.l: Remove obsolete

--- a/gas/testsuite/gas/riscv/cv-hwlp-march-rv32i-xcorev.s
+++ b/gas/testsuite/gas/riscv/cv-hwlp-march-rv32i-xcorev.s
@@ -1,8 +1,8 @@
 # xcorev march option works for all CORE-V hwloop extensions
 target:
 	cv.starti 1, 320
-        cv.endi   1, 1056
-        cv.setupi 1, 488, 12
-        cv.setup  1, t5, 488
-        cv.count  1, a1
-        cv.counti 1, 1937
+	cv.endi   1, 1056
+	cv.setupi 1, 488, 12
+	cv.setup  1, t5, 488
+	cv.count  1, a1
+	cv.counti 1, 1937

--- a/opcodes/ChangeLog.COREV
+++ b/opcodes/ChangeLog.COREV
@@ -1,3 +1,7 @@
+2021-02-19  Jessica Mills  <jessica.mills@embecosm.com>
+
+	* riscv-dis.c: Fix whitespace inconsistency.
+
 2021-01-11  Jessica Mills  <jessica.mills@embecosm.com>
 
 	* riscv-opc.h (MATCH_MACS, MATCH_MACHHS, MATCH_MACU)

--- a/opcodes/riscv-dis.c
+++ b/opcodes/riscv-dis.c
@@ -279,7 +279,7 @@ print_insn_args (const char *d, insn_t l, bfd_vma pc, disassemble_info *info)
 	      info->target = (EXTRACT_ITYPE_IMM (l)<<1) + pc; ++d;
 	      (*info->print_address_func) (info->target, info);
 	      break;
-            }
+	    }
 	  else if (d[1] == '2')
 	    {
 	      info->target = (EXTRACT_CV_HWLP_UIMM5 (l)<<1) + pc; ++d;


### PR DESCRIPTION
gas/testsuite/ChangeLog.COREV:

	* gas/riscv/cv-hwlp-march-rv32i-xcorev.s: Fix whitespace
	inconsistencies.

opcodes/ChangeLog.COREV:

	* riscv-dis.c: Fix whitespace inconsistency.

Signed-off-by: Jessica Mills <jessica.mills@embecosm.com>