### PR TITLE
Add branching immediate instructions, and GAS tests

### DIFF
--- a/gas/ChangeLog.COREV
+++ b/gas/ChangeLog.COREV
@@ -1,3 +1,14 @@
+2021-08-10  Nazareno Bruschi  <nazareno.bruschi@embecosm.com>
+
+	* config/tc-riscv.c (riscv_multi_subset_supports): Add immediate
+	branching instruction class.
+	(validate_riscv_insn, riscv_ip): Rename macro
+	ENCODE_CV_ALU_UIMM5 -> ENCODE_CV_UIMM5.
+	(validate_riscv_insn, riscv_ip): Add immediate branching
+	operand and modify PC-relative offset operand.
+	* doc/c-riscv.texi: Add details on CORE-V immediate
+	branching ops ISA options.
+
 2021-08-06  Enrico Tabanelli  <enrico.tabanelli@embecosm.com>
 
 	* config/tc-riscv.c (riscv_multi_subset_supports): Add 

--- a/gas/config/tc-riscv.c
+++ b/gas/config/tc-riscv.c
@@ -362,6 +362,9 @@ riscv_multi_subset_supports (enum riscv_insn_class insn_class)
     case INSN_CLASS_COREV_MEM:
       return riscv_subset_supports ("xcorevmem") || riscv_subset_supports ("xcorev");
 
+    case INSN_CLASS_COREV_BI:
+      return riscv_subset_supports ("xcorevbi") || riscv_subset_supports ("xcorev");
+
     default:
       as_fatal ("internal: unreachable");
       return false;
@@ -1122,9 +1125,14 @@ validate_riscv_insn (const struct riscv_opcode *opc, int length)
 	    used_bits |= ENCODE_CV_MAC_UIMM5(-1U);
 	    ++p; break;
 	  }
+	else if (*p == '4')
+	  {
+	    used_bits |= ENCODE_CV_UIMM5(-1U);
+	    ++p; break;
+	  }
 	else if (*p == 'i')
 	  {
-	    used_bits |= ENCODE_CV_ALU_UIMM5(-1U);
+	    used_bits |= ENCODE_CV_UIMM5(-1U);
 	    ++p; break;
 	  }
 	break;
@@ -2592,6 +2600,7 @@ riscv_ip (char *str, struct riscv_cl_insn *ip, expressionS *imm_expr,
 		     sign-extended immediate as pc rel displacement for hwloop
 		 b2: pc rel 5 bits unsigned offset for cv.setupi
 		 b3: 5 bits usigned offset for MAC
+		 b4: 5 bits signed immediate bits[24..20]
 		 bi: 5 bits unsigned offset for cv.clip and cv.clipu
 		     ALU luimm5 [24...20]	 */
 	    case 'b':
@@ -2659,13 +2668,24 @@ riscv_ip (char *str, struct riscv_cl_insn *ip, expressionS *imm_expr,
 		  ip->insn_opcode |= ENCODE_CV_MAC_UIMM5 (imm_expr->X_add_number);
 		  ++args;
 		}
+	      else if (args[1] == '4')
+		{
+		  my_getExpression (imm_expr, s);
+		  check_absolute_expr (ip, imm_expr, FALSE);
+		  s = expr_end;
+		  if (imm_expr->X_add_number<-16 || imm_expr->X_add_number>15)
+		  as_bad(_("immediate value must be 5-bit signed, %ld is out of range"),
+		  imm_expr->X_add_number);
+		  ip->insn_opcode |= ENCODE_CV_UIMM5 (imm_expr->X_add_number);
+		  ++args;
+		}
 	      else if (args[1] == 'i')
 		{
 		  my_getExpression (imm_expr, s);
 		  check_absolute_expr (ip, imm_expr, FALSE);
 		  s = expr_end;
 		  if (imm_expr->X_add_number<0 || imm_expr->X_add_number>31) break;
-		  ip->insn_opcode |= ENCODE_CV_ALU_UIMM5 (imm_expr->X_add_number);
+		  ip->insn_opcode |= ENCODE_CV_UIMM5 (imm_expr->X_add_number);
 		  ++args;
 		}
 	      else

--- a/gas/doc/c-riscv.texi
+++ b/gas/doc/c-riscv.texi
@@ -57,6 +57,8 @@ multiply-accumulate: @samp{Xcorevmac}
 general ALU operations: @samp{Xcorevalu}
 @item
 Post-incrementing and reg-reg load/store: @samp{Xcorevmem}
+@item
+immediate branching: @samp{Xcorevbi}
 @end itemize
 
 @cindex @samp{-misa-spec=ISAspec} option, RISC-V

--- a/gas/testsuite/ChangeLog.COREV
+++ b/gas/testsuite/ChangeLog.COREV
@@ -1,3 +1,27 @@
+2021-08-10  Nazareno Bruschi  <nazareno.bruschi@embecosm.com>
+
+	* gas/riscv/cv-bi-beqimm.d: Add immediate branching test.
+	* gas/riscv/cv-bi-beqimm.s: Likewise.
+	* gas/riscv/cv-bi-bneimm.d: Likewise.
+	* gas/riscv/cv-bi-bneimm.s: Likewise.
+	* gas/riscv/cv-bi-fail-march.d: Likewise.
+	* gas/riscv/cv-bi-fail-march.l: Likewise.
+	* gas/riscv/cv-bi-fail-march.s: Likewise.
+	* gas/riscv/cv-bi-fail-operand-01.d: Likewise.
+	* gas/riscv/cv-bi-fail-operand-01.l: Likewise.
+	* gas/riscv/cv-bi-fail-operand-01.s: Likewise.
+	* gas/riscv/cv-bi-fail-operand-02.d: Likewise.
+	* gas/riscv/cv-bi-fail-operand-02.l: Likewise.
+	* gas/riscv/cv-bi-fail-operand-02.s: Likewise.
+	* gas/riscv/cv-bi-fail-operand-03.d: Likewise.
+	* gas/riscv/cv-bi-fail-operand-03.l: Likewise.
+	* gas/riscv/cv-bi-fail-operand-03.s: Likewise.
+	* gas/riscv/cv-bi-fail-operand-04.d: Likewise.
+	* gas/riscv/cv-bi-fail-operand-04.l: Likewise.
+	* gas/riscv/cv-bi-fail-operand-04.s: Likewise.
+	* gas/riscv/cv-bi-march-rv32i-xcorev.d: Likewise.
+	* gas/riscv/cv-bi-march-rv32i-xcorev.s: Likewise.
+
 2021-08-06  Enrico Tabanelli  <enrico.tabanelli@embecosm.com>
 
 	* gas/riscv/cv-mem-fail-operand-01.d: Add post-increment

--- a/gas/testsuite/gas/riscv/cv-bi-beqimm.d
+++ b/gas/testsuite/gas/riscv/cv-bi-beqimm.d
@@ -1,0 +1,12 @@
+#as: -march=rv32i_xcorevbi1p0
+#objdump: -d
+
+.*:[ 	]+file format .*
+
+
+Disassembly of section .text:
+
+0+000 <foo>:
+[ 	]+0:[ 	]+0102a063[ 	]+cv.beqimm[ 	]+t0,-16,0 +<foo>
+[ 	]+4:[ 	]+fe5eaee3[ 	]+cv.beqimm[ 	]+t4,5,0 +<foo>
+[ 	]+8:[ 	]+fef3ace3[ 	]+cv.beqimm[ 	]+t2,15,0 +<foo>

--- a/gas/testsuite/gas/riscv/cv-bi-beqimm.s
+++ b/gas/testsuite/gas/riscv/cv-bi-beqimm.s
@@ -1,0 +1,4 @@
+foo:
+	cv.beqimm t0, -16, foo
+	cv.beqimm t4, 5, foo
+	cv.beqimm t2, 15, foo

--- a/gas/testsuite/gas/riscv/cv-bi-bneimm.d
+++ b/gas/testsuite/gas/riscv/cv-bi-bneimm.d
@@ -1,0 +1,12 @@
+#as: -march=rv32i_xcorevbi1p0
+#objdump: -d
+
+.*:[ 	]+file format .*
+
+
+Disassembly of section .text:
+
+0+000 <foo>:
+[ 	]+0:[ 	]+0102b063[ 	]+cv.bneimm[ 	]+t0,-16,0 +<foo>
+[ 	]+4:[ 	]+fe5ebee3[ 	]+cv.bneimm[ 	]+t4,5,0 +<foo>
+[ 	]+8:[ 	]+fef3bce3[ 	]+cv.bneimm[ 	]+t2,15,0 +<foo>

--- a/gas/testsuite/gas/riscv/cv-bi-bneimm.s
+++ b/gas/testsuite/gas/riscv/cv-bi-bneimm.s
@@ -1,0 +1,4 @@
+foo:
+	cv.bneimm t0, -16, foo
+	cv.bneimm t4, 5, foo
+	cv.bneimm t2, 15, foo

--- a/gas/testsuite/gas/riscv/cv-bi-fail-march.d
+++ b/gas/testsuite/gas/riscv/cv-bi-fail-march.d
@@ -1,0 +1,3 @@
+#as: -march=rv32i
+#source: cv-bi-fail-march.s
+#error_output: cv-bi-fail-march.l

--- a/gas/testsuite/gas/riscv/cv-bi-fail-march.l
+++ b/gas/testsuite/gas/riscv/cv-bi-fail-march.l
@@ -1,0 +1,3 @@
+.*: Assembler messages:
+.*: Error: unrecognized opcode `cv.beqimm t2,1,foo'
+.*: Error: unrecognized opcode `cv.bneimm t2,1,foo'

--- a/gas/testsuite/gas/riscv/cv-bi-fail-march.s
+++ b/gas/testsuite/gas/riscv/cv-bi-fail-march.s
@@ -1,0 +1,5 @@
+# Absence of xcorev or xcorevbi march option disables all CORE-V
+# immediate branching extensions.
+foo:
+	cv.beqimm t2, 1, foo
+	cv.bneimm t2, 1, foo

--- a/gas/testsuite/gas/riscv/cv-bi-fail-operand-01.d
+++ b/gas/testsuite/gas/riscv/cv-bi-fail-operand-01.d
@@ -1,0 +1,3 @@
+#as: -march=rv32i_xcorevbi1p0
+#source: cv-bi-fail-operand-01.s
+#error_output: cv-bi-fail-operand-01.l

--- a/gas/testsuite/gas/riscv/cv-bi-fail-operand-01.l
+++ b/gas/testsuite/gas/riscv/cv-bi-fail-operand-01.l
@@ -1,0 +1,3 @@
+.*: Assembler messages:
+.*: Error: illegal operands `cv.beqimm 20,10,foo'
+.*: Error: illegal operands `cv.bneimm 8,-4,foo'

--- a/gas/testsuite/gas/riscv/cv-bi-fail-operand-01.s
+++ b/gas/testsuite/gas/riscv/cv-bi-fail-operand-01.s
@@ -1,0 +1,4 @@
+# Comparison target must be a register
+foo:
+	cv.beqimm 20, 10, foo
+	cv.bneimm 8, -4, foo

--- a/gas/testsuite/gas/riscv/cv-bi-fail-operand-02.d
+++ b/gas/testsuite/gas/riscv/cv-bi-fail-operand-02.d
@@ -1,0 +1,3 @@
+#as: -march=rv32i_xcorevbi1p0
+#source: cv-bi-fail-operand-02.s
+#error_output: cv-bi-fail-operand-02.l

--- a/gas/testsuite/gas/riscv/cv-bi-fail-operand-02.l
+++ b/gas/testsuite/gas/riscv/cv-bi-fail-operand-02.l
@@ -1,0 +1,3 @@
+.*: Assembler messages:
+.*: Error: instruction cv.beqimm requires absolute expression
+.*: Error: instruction cv.bneimm requires absolute expression

--- a/gas/testsuite/gas/riscv/cv-bi-fail-operand-02.s
+++ b/gas/testsuite/gas/riscv/cv-bi-fail-operand-02.s
@@ -1,0 +1,4 @@
+# Comparison value must be an immediate
+foo:
+	cv.beqimm t0, t1, foo
+	cv.bneimm t3, t4, foo

--- a/gas/testsuite/gas/riscv/cv-bi-fail-operand-03.d
+++ b/gas/testsuite/gas/riscv/cv-bi-fail-operand-03.d
@@ -1,0 +1,3 @@
+#as: -march=rv32i_xcorevbi1p0
+#source: cv-bi-fail-operand-03.s
+#error_output: cv-bi-fail-operand-03.l

--- a/gas/testsuite/gas/riscv/cv-bi-fail-operand-03.l
+++ b/gas/testsuite/gas/riscv/cv-bi-fail-operand-03.l
@@ -1,0 +1,9 @@
+.*: Assembler messages:
+.*: Error: immediate value must be 5-bit signed, -17 is out of range
+.*: Error: immediate value must be 5-bit signed, -32 is out of range
+.*: Error: immediate value must be 5-bit signed, 16 is out of range
+.*: Error: immediate value must be 5-bit signed, 44 is out of range
+.*: Error: immediate value must be 5-bit signed, -17 is out of range
+.*: Error: immediate value must be 5-bit signed, -32 is out of range
+.*: Error: immediate value must be 5-bit signed, 16 is out of range
+.*: Error: immediate value must be 5-bit signed, 44 is out of range

--- a/gas/testsuite/gas/riscv/cv-bi-fail-operand-03.s
+++ b/gas/testsuite/gas/riscv/cv-bi-fail-operand-03.s
@@ -1,0 +1,10 @@
+# Comparison value must be an immediate in range [-16, +15]
+foo:
+	cv.beqimm t0, -17, foo
+	cv.beqimm t2, -32, foo
+	cv.beqimm t4, 16, foo
+	cv.beqimm t3, 44, foo
+	cv.bneimm t0, -17, foo
+	cv.bneimm t2, -32, foo
+	cv.bneimm t4, 16, foo
+	cv.bneimm t3, 44, foo

--- a/gas/testsuite/gas/riscv/cv-bi-march-rv32i-xcorev.d
+++ b/gas/testsuite/gas/riscv/cv-bi-march-rv32i-xcorev.d
@@ -1,0 +1,11 @@
+#as: -march=rv32i_xcorev1p0
+#objdump: -d
+
+.*:[ 	]+file format .*
+
+
+Disassembly of section .text:
+
+0+000 <foo>:
+[ 	]+0:[ 	]+0013a063[ 	]+cv.beqimm[ 	]+t2,1,0 +<foo>
+[ 	]+4:[ 	]+ff02bee3[ 	]+cv.bneimm[ 	]+t0,-16,0 +<foo>

--- a/gas/testsuite/gas/riscv/cv-bi-march-rv32i-xcorev.s
+++ b/gas/testsuite/gas/riscv/cv-bi-march-rv32i-xcorev.s
@@ -1,0 +1,4 @@
+# xcorev march option works for all CORE-V immediate branching extensions
+foo:
+	cv.beqimm t2, 1, foo
+	cv.bneimm t0, -16, foo

--- a/include/ChangeLog.COREV
+++ b/include/ChangeLog.COREV
@@ -1,3 +1,13 @@
+2021-08-10  Nazareno Bruschi  <nazareno.bruschi@embecosm.com>
+
+	* opcode/riscv-opc.h: Add immediate branching matches and
+	masks.
+	* opcode/riscv.h (riscv_insn_class, EXTRACT_CV_BI_IMM5):
+	Add immediate branching class and macros for 5-bit signed
+	immediate.
+	(ENCODE_CV_ALU_UIMM5): Rename macro as ENCODE_CV_UIMM5.
+	(RV_IMM_SIGN_N): Add macro for general sign extraction.
+
 2021-08-06  Enrico Tabanelli  <enrico.tabanelli@embecosm.com>
 
 	* riscv-opc.h: Add post-increment and register-indexed 

--- a/include/opcode/riscv-opc.h
+++ b/include/opcode/riscv-opc.h
@@ -957,6 +957,12 @@
 #define MASK_CV_ABS      0xFFF0707F
 #define MASK_CV_SLET     0xFE00707F
 #define MASK_CV_ADDN     0xC000707F
+/* Immediate Branching */
+#define MATCH_CV_BNEIMM    0x00003063
+#define MATCH_CV_BEQIMM    0x00002063
+
+#define MASK_CV_BNEIMM     0x0000707f
+#define MASK_CV_BEQIMM     0x0000707f
 
 /* Post-incrementing and reg-reg load/store */
 #define MATCH_CV_LBPOST    0xb

--- a/include/opcode/riscv.h
+++ b/include/opcode/riscv.h
@@ -67,6 +67,7 @@ static const char * const riscv_pred_succ[16] =
 
 #define RV_X(x, s, n)  (((x) >> (s)) & ((1 << (n)) - 1))
 #define RV_IMM_SIGN(x) (-(((x) >> 31) & 1))
+#define RV_IMM_SIGN_N(x, s, n) (-(((x) >> ((s) + (n) - 1)) & 1))
 
 #define EXTRACT_ITYPE_IMM(x) \
   (RV_X(x, 20, 12) | (RV_IMM_SIGN(x) << 12))
@@ -120,6 +121,8 @@ static const char * const riscv_pred_succ[16] =
   (RV_X(x, 25, 5))
 #define EXTRACT_CV_ALU_UIMM5(x) \
   (RV_X(x, 20, 5))
+#define EXTRACT_CV_BI_IMM5(x) \
+  (RV_X(x, 20, 5) | (RV_IMM_SIGN_N(x, 20, 5) << 5))
 
 #define ENCODE_ITYPE_IMM(x) \
   (RV_X(x, 0, 12) << 20)
@@ -163,6 +166,8 @@ static const char * const riscv_pred_succ[16] =
   ((RV_X(x, 1, 3) << 3) | (RV_X(x, 4, 1) << 11) | (RV_X(x, 5, 1) << 2) | (RV_X(x, 6, 1) << 7) | (RV_X(x, 7, 1) << 6) | (RV_X(x, 8, 2) << 9) | (RV_X(x, 10, 1) << 8) | (RV_X(x, 11, 1) << 12))
 
 /* CORE-V Specific.  */
+#define ENCODE_CV_UIMM5(x) \
+  (RV_X(x, 0, 5) << 20)
 #define ENCODE_CV_HWLP_UIMM5(x) \
   (RV_X(x, 0, 5) << 15)
 #define ENCODE_CV_HWLP_LN(x) \
@@ -359,7 +364,8 @@ enum riscv_insn_class
   INSN_CLASS_COREV_HWLP,
   INSN_CLASS_COREV_MAC,
   INSN_CLASS_COREV_ALU,
-  INSN_CLASS_COREV_MEM
+  INSN_CLASS_COREV_MEM,
+  INSN_CLASS_COREV_BI
 };
 
 /* This structure holds information for a particular instruction.  */

--- a/ld/testsuite/ChangeLog.COREV
+++ b/ld/testsuite/ChangeLog.COREV
@@ -1,3 +1,12 @@
+2021-08-10  Nazareno Bruschi  <nazareno.bruschi@embecosm.com>
+
+	* ld-riscv-elf/cv-bi-beqimm.d: Add new test.
+	* ld-riscv-elf/cv-bi-beqimm.s: Likewise.
+	* ld-riscv-elf/cv-bi-bneimm.d: Likewise.
+	* ld-riscv-elf/cv-bi-bneimm.s: Likewise.
+	* ld-riscv-elf/ld-riscv-elf.exp: Add CORE-V immediate
+	branching tests.
+
 2020-10-21  Mary Bennett  <mary.bennett@embecosm.com>
 
 	* ld-riscv-elf/cv-hwloop-starti.d: Changed march option to xcorevhwlp.

--- a/ld/testsuite/ld-riscv-elf/cv-bi-beqimm.d
+++ b/ld/testsuite/ld-riscv-elf/cv-bi-beqimm.d
@@ -1,0 +1,21 @@
+#name: beqimm relocation
+#source: cv-bi-beqimm.s
+#as: -march=rv32i_xcorevbi1p0
+#ld: -melf32lriscv
+#objdump: -dr
+
+.*:     file format .*
+
+
+Disassembly of section \.text:
+
+.* <func>:
+.*:[[:space:]]+00008067[[:space:]]+ret
+
+.* <_start>:
+.*:[[:space:]]+0102a463[[:space:]]+cv.beqimm[[:space:]]+t0,-16,10060 <L2>
+.*:[[:space:]]+ff9ff0ef[[:space:]]+jal[[:space:]]+ra,10054 <func>
+
+.* <L2>:
+.*:[[:space:]]+00000013[[:space:]]+nop
+#pass

--- a/ld/testsuite/ld-riscv-elf/cv-bi-beqimm.s
+++ b/ld/testsuite/ld-riscv-elf/cv-bi-beqimm.s
@@ -1,0 +1,11 @@
+        .option nopic
+        .text
+        .align 1
+        .globl _start
+        .type _start, @function
+
+func:   ret
+_start:
+        cv.beqimm       t0, -16, L2
+        call func
+L2:     nop

--- a/ld/testsuite/ld-riscv-elf/cv-bi-bneimm.d
+++ b/ld/testsuite/ld-riscv-elf/cv-bi-bneimm.d
@@ -1,0 +1,21 @@
+#name: bneimm relocation
+#source: cv-bi-bneimm.s
+#as: -march=rv32i_xcorevbi1p0
+#ld: -melf32lriscv
+#objdump: -dr
+
+.*:     file format .*
+
+
+Disassembly of section \.text:
+
+.* <func>:
+.*:[[:space:]]+00008067[[:space:]]+ret
+
+.* <_start>:
+.*:[[:space:]]+0102b463[[:space:]]+cv.bneimm[[:space:]]+t0,-16,10060 <L2>
+.*:[[:space:]]+ff9ff0ef[[:space:]]+jal[[:space:]]+ra,10054 <func>
+
+.* <L2>:
+.*:[[:space:]]+00000013[[:space:]]+nop
+#pass

--- a/ld/testsuite/ld-riscv-elf/cv-bi-bneimm.s
+++ b/ld/testsuite/ld-riscv-elf/cv-bi-bneimm.s
@@ -1,0 +1,11 @@
+        .option nopic
+        .text
+        .align 1
+        .globl _start
+        .type _start, @function
+
+func:   ret
+_start:
+        cv.bneimm       t0, -16, L2
+        call func
+L2:     nop

--- a/ld/testsuite/ld-riscv-elf/ld-riscv-elf.exp
+++ b/ld/testsuite/ld-riscv-elf/ld-riscv-elf.exp
@@ -114,6 +114,8 @@ if [istarget "riscv*-*-*"] {
     run_dump_test "cv-hwloop-endi"
     run_dump_test "cv-hwloop-setup"
     run_dump_test "cv-hwloop-setupi"
+    run_dump_test "cv-bi-bneimm"
+    run_dump_test "cv-bi-beqimm"
     run_ld_link_tests [list \
 	[list "Weak reference 32" "-T weakref.ld -m[riscv_choose_ilp32_emul]" "" \
 	    "-march=rv32i -mabi=ilp32" {weakref32.s} \

--- a/opcodes/ChangeLog.COREV
+++ b/opcodes/ChangeLog.COREV
@@ -1,3 +1,10 @@
+2021-08-10  Nazareno Bruschi  <nazareno.bruschi@embecosm.com>
+
+	* riscv-dis.c (print_insn_args): Add immediate branching
+	operand.
+	* riscv-opc.c (riscv_opcodes): Add immediate branching
+	opcodes.
+
 2021-08-06  Enrico Tabanelli  <enrico.tabanelli@embecosm.com>
 
 	* riscv-dis.c (print_insn_args): Add post-increment symbol. 

--- a/opcodes/riscv-dis.c
+++ b/opcodes/riscv-dis.c
@@ -303,6 +303,12 @@ print_insn_args (const char *d, insn_t l, bfd_vma pc, disassemble_info *info)
 	      ++d;
 	      break;
 	    }
+	  else if (d[1] == '4')
+	    {
+	      print (info->stream, "%d", ((int) EXTRACT_CV_BI_IMM5 (l)));
+	      ++d;
+	      break;
+	    }
 	  else if (d[1] == 'i')
 	    {
 	      print (info->stream, "%d", ((int) EXTRACT_CV_ALU_UIMM5 (l)));

--- a/opcodes/riscv-opc.c
+++ b/opcodes/riscv-opc.c
@@ -935,6 +935,10 @@ const struct riscv_opcode riscv_opcodes[] =
 {"cv.sw", 0, INSN_CLASS_COREV_MEM, "t,d(s)",  MATCH_CV_SWRR,      MASK_CV_SRR,      match_opcode, 0},
 {"cv.sw", 0, INSN_CLASS_COREV_MEM, "t,d(s!)", MATCH_CV_SWRRPOST,  MASK_CV_SRRPOST,  match_opcode, 0},
 
+/* Immediate branching */
+{"cv.beqimm", 0, INSN_CLASS_COREV_BI, "s,b4,p", MATCH_CV_BEQIMM, MASK_CV_BEQIMM, match_opcode, 0},
+{"cv.bneimm", 0, INSN_CLASS_COREV_BI, "s,b4,p", MATCH_CV_BNEIMM, MASK_CV_BNEIMM, match_opcode, 0},
+
 /* Terminate the list.  */
 {0, 0, INSN_CLASS_NONE, 0, 0, 0, 0, 0}
 };


### PR DESCRIPTION
gas/Changelog.COREV:

	* config/tc-riscv.c (riscv_multi_subset_supports): Add immediate
	branching instruction class.
	(validate_riscv_insn, riscv_ip): Rename macro
	ENCODE_CV_ALU_UIMM5 -> ENCODE_CV_UIMM5.
	(validate_riscv_insn, riscv_ip): Add immediate branching
	operand and modify PC-relative offset operand.
	* doc/c-riscv.texi: Add details on CORE-V immediate
	branching ops ISA options.

gas/testsuite/Changelog.COREV:

	* gas/riscv/cv-bi-beqimm.d: Add immediate branching test.
	* gas/riscv/cv-bi-beqimm.s: Likewise.
	* gas/riscv/cv-bi-bneimm.d: Likewise.
	* gas/riscv/cv-bi-bneimm.s: Likewise.
	* gas/riscv/cv-bi-fail-march.d: Likewise.
	* gas/riscv/cv-bi-fail-march.l: Likewise.
	* gas/riscv/cv-bi-fail-march.s: Likewise.
	* gas/riscv/cv-bi-fail-operand-01.d: Likewise.
	* gas/riscv/cv-bi-fail-operand-01.l: Likewise.
	* gas/riscv/cv-bi-fail-operand-01.s: Likewise.
	* gas/riscv/cv-bi-fail-operand-02.d: Likewise.
	* gas/riscv/cv-bi-fail-operand-02.l: Likewise.
	* gas/riscv/cv-bi-fail-operand-02.s: Likewise.
	* gas/riscv/cv-bi-fail-operand-03.d: Likewise.
	* gas/riscv/cv-bi-fail-operand-03.l: Likewise.
	* gas/riscv/cv-bi-fail-operand-03.s: Likewise.
	* gas/riscv/cv-bi-fail-operand-04.d: Likewise.
	* gas/riscv/cv-bi-fail-operand-04.l: Likewise.
	* gas/riscv/cv-bi-fail-operand-04.s: Likewise.
	* gas/riscv/cv-bi-march-rv32i-xcorev.d: Likewise.
	* gas/riscv/cv-bi-march-rv32i-xcorev.s: Likewise.

include/Changelog.COREV:

	* opcode/riscv-opc.h: Add immediate branching matches and
	masks.
	* opcode/riscv.h (riscv_insn_class, EXTRACT_CV_BI_IMM5):
	Add immediate branching class and macros for 5-bit signed
	immediate.
	(ENCODE_CV_ALU_UIMM5): Rename macro as ENCODE_CV_UIMM5.
	(RV_IMM_SIGN_N): Add macro for general sign extraction.

ld/testsuite/Changelog.COREV:

	* ld-riscv-elf/cv-bi-beqimm.d: Add new test.
	* ld-riscv-elf/cv-bi-beqimm.s: Likewise.
	* ld-riscv-elf/cv-bi-bneimm.d: Likewise.
	* ld-riscv-elf/cv-bi-bneimm.s: Likewise.
	* ld-riscv-elf/ld-riscv-elf.exp: Add CORE-V immediate
	branching tests.

opcodes/Changelog.COREV:

	* riscv-dis.c (print_insn_args): Add immediate branching
	operand.
	* riscv-opc.c (riscv_opcodes): Add immediate branching
	opcodes.

Signed-off-by: Nazareno Bruschi <nazareno.bruschi@embecosm.com>