### PR TITLE
Changed hardware loop encodings to CV32E40P

### DIFF
--- a/gas/testsuite/gas/riscv/cv-hwlp-count.d
+++ b/gas/testsuite/gas/riscv/cv-hwlp-count.d
@@ -7,6 +7,6 @@
 Disassembly of section .text:
 
 0+000 <target>:
-[ 	]+0:[ 	]+0002a07b[ 	]+cv.count[ 	]+0,t0
-[ 	]+4:[ 	]+0005a0fb[ 	]+cv.count[ 	]+1,a1
-[ 	]+8:[ 	]+000ea07b[ 	]+cv.count[ 	]+0,t4
+[ 	]+0:[ 	]+0002c52b[ 	]+cv.count[ 	]+0,t0
+[ 	]+4:[ 	]+0005c5ab[ 	]+cv.count[ 	]+1,a1
+[ 	]+8:[ 	]+000ec52b[ 	]+cv.count[ 	]+0,t4

--- a/gas/testsuite/gas/riscv/cv-hwlp-counti.d
+++ b/gas/testsuite/gas/riscv/cv-hwlp-counti.d
@@ -7,6 +7,6 @@
 Disassembly of section .text:
 
 0+000 <target>:
-[ 	]+0:[ 	]+0000307b[ 	]+cv.counti[ 	]+0,0
-[ 	]+4:[ 	]+791030fb[ 	]+cv.counti[ 	]+1,1937
-[ 	]+8:[ 	]+fff0307b[ 	]+cv.counti[ 	]+0,4095
+[ 	]+0:[ 	]+0000442b[ 	]+cv.counti[ 	]+0,0
+[ 	]+4:[ 	]+791044ab[ 	]+cv.counti[ 	]+1,1937
+[ 	]+8:[ 	]+fff0442b[ 	]+cv.counti[ 	]+0,4095

--- a/gas/testsuite/gas/riscv/cv-hwlp-endi.d
+++ b/gas/testsuite/gas/riscv/cv-hwlp-endi.d
@@ -7,6 +7,6 @@
 Disassembly of section .text:
 
 0+000 <target>:
-[ 	]+0:[ 	]+0000107b[ 	]+cv.endi[ 	]+0,0 <target>
-[ 	]+4:[ 	]+210010fb[ 	]+cv.endi[ 	]+1,424 +<target\+0x424>
-[ 	]+8:[ 	]+fff0107b[ 	]+cv.endi[ 	]+0,6 +<target\+0x6>
+[ 	]+0:[ 	]+0000422b[ 	]+cv.endi[ 	]+0,0 <target>
+[ 	]+4:[ 	]+210042ab[ 	]+cv.endi[ 	]+1,424 +<target\+0x424>
+[ 	]+8:[ 	]+fff0422b[ 	]+cv.endi[ 	]+0,6 +<target\+0x6>

--- a/gas/testsuite/gas/riscv/cv-hwlp-march-rv32i-xcorev.d
+++ b/gas/testsuite/gas/riscv/cv-hwlp-march-rv32i-xcorev.d
@@ -7,9 +7,9 @@
 Disassembly of section .text:
 
 0+000 <target>:
-[ 	]+0:[ 	]+0a0000fb[ 	]+cv.starti[ 	]+1,140 +<target\+0x140>
-[ 	]+4:[ 	]+210010fb[ 	]+cv.endi[ 	]+1,424 +<target\+0x424>
-[ 	]+8:[ 	]+1e8350fb[ 	]+cv.setupi[ 	]+1,488,14 <target\+0x14>
-[ 	]+c:[ 	]+0f4f40fb[ 	]+cv.setup[ 	]+1,t5,1f4 <target\+0x1f4>
-[ 	]+10:[ 	]+0005a0fb[ 	]+cv.count[ 	]+1,a1
-[ 	]+14:[ 	]+791030fb[ 	]+cv.counti[ 	]+1,1937
+[ 	]+0:[ 	]+0a0040ab[ 	]+cv.starti[ 	]+1,140 +<target\+0x140>
+[ 	]+4:[ 	]+210042ab[ 	]+cv.endi[ 	]+1,424 +<target\+0x424>
+[ 	]+8:[ 	]+1e8346ab[ 	]+cv.setupi[ 	]+1,488,14 <target\+0x14>
+[ 	]+c:[ 	]+0f4f47ab[ 	]+cv.setup[ 	]+1,t5,1f4 <target\+0x1f4>
+[ 	]+10:[ 	]+0005c5ab[ 	]+cv.count[ 	]+1,a1
+[ 	]+14:[ 	]+791044ab[ 	]+cv.counti[ 	]+1,1937

--- a/gas/testsuite/gas/riscv/cv-hwlp-setup.d
+++ b/gas/testsuite/gas/riscv/cv-hwlp-setup.d
@@ -7,6 +7,6 @@
 Disassembly of section .text:
 
 0+000 <target>:
-[ 	]+0:[ 	]+0002c07b[ 	]+cv.setup[ 	]+0,t0,0 <target>
-[ 	]+4:[ 	]+0f4f40fb[ 	]+cv.setup[ 	]+1,t5,1ec <target\+0x1ec>
-[ 	]+8:[ 	]+fff5407b[ 	]+cv.setup[ 	]+0,a0,6 <target\+0x6>
+[ 	]+0:[ 	]+0002c72b[ 	]+cv.setup[ 	]+0,t0,0 <target>
+[ 	]+4:[ 	]+0f4f47ab[ 	]+cv.setup[ 	]+1,t5,1ec <target\+0x1ec>
+[ 	]+8:[ 	]+fff5472b[ 	]+cv.setup[ 	]+0,a0,6 <target\+0x6>

--- a/gas/testsuite/gas/riscv/cv-hwlp-setupi.d
+++ b/gas/testsuite/gas/riscv/cv-hwlp-setupi.d
@@ -7,6 +7,6 @@
 Disassembly of section .text:
 
 0+000 <target>:
-[ 	]+0:[ 	]+0000507b[ 	]+cv.setupi[ 	]+0,0,0 <target>
-[ 	]+4:[ 	]+1e8350fb[ 	]+cv.setupi[ 	]+1,488,10 <target\+0x10>
-[ 	]+8:[ 	]+fff7d07b[ 	]+cv.setupi[ 	]+0,4095,26 <target\+0x26>
+[ 	]+0:[ 	]+0000462b[ 	]+cv.setupi[ 	]+0,0,0 <target>
+[ 	]+4:[ 	]+1e8346ab[ 	]+cv.setupi[ 	]+1,488,10 <target\+0x10>
+[ 	]+8:[ 	]+fff7c62b[ 	]+cv.setupi[ 	]+0,4095,26 <target\+0x26>

--- a/gas/testsuite/gas/riscv/cv-hwlp-starti.d
+++ b/gas/testsuite/gas/riscv/cv-hwlp-starti.d
@@ -7,6 +7,6 @@
 Disassembly of section .text:
 
 0+000 <target>:
-[ 	]+0:[ 	]+0000007b[ 	]+cv.starti[ 	]+0,0 <target>
-[ 	]+4:[ 	]+5e6000fb[ 	]+cv.starti[ 	]+1,bd0 +<target\+0xbd0>
-[ 	]+8:[ 	]+fff0007b[ 	]+cv.starti[ 	]+0,6 +<target\+0x6>
+[ 	]+0:[ 	]+0000402b[ 	]+cv.starti[ 	]+0,0 <target>
+[ 	]+4:[ 	]+5e6040ab[ 	]+cv.starti[ 	]+1,bd0 +<target\+0xbd0>
+[ 	]+8:[ 	]+fff0402b[ 	]+cv.starti[ 	]+0,6 +<target\+0x6>

--- a/include/opcode/riscv-opc.h
+++ b/include/opcode/riscv-opc.h
@@ -2476,12 +2476,12 @@
 #define MASK_CV_SETUP  0x7f7f
 #define MASK_CV_SETUPI 0x7f7f
 
-#define MATCH_CV_STARTI 0x7b
-#define MATCH_CV_ENDI   0x107b
-#define MATCH_CV_COUNT  0x207b
-#define MATCH_CV_COUNTI 0x307b
-#define MATCH_CV_SETUP  0x407b
-#define MATCH_CV_SETUPI 0x507b
+#define MATCH_CV_STARTI 0x402b
+#define MATCH_CV_ENDI   0x422b
+#define MATCH_CV_COUNT  0x452b
+#define MATCH_CV_COUNTI 0x442b
+#define MATCH_CV_SETUP  0x472b
+#define MATCH_CV_SETUPI 0x462b
 
 /* Multiply accumulate */
 #define MATCH_CV_MAC       0x9000302b

--- a/opcodes/riscv-dis.c
+++ b/opcodes/riscv-dis.c
@@ -690,7 +690,9 @@ print_insn_args (const char *oparg, insn_t l, bfd_vma pc, disassemble_info *info
 	  if (oparg[1] == 'i')
 	    {
 	      ++oparg;
-	      print (info->stream, dis_style_immediate, "%d", (int) rd);
+	      /* di refers to just bit 7. Therefore we have masked the top 4 bits
+	       *  of rd, bits 11 to 7. */
+	      print (info->stream, dis_style_immediate, "%d", (int) (rd & 0b00001));
 	    }
 	  else
 	    print (info->stream, dis_style_register, "%s", riscv_gpr_names[rd]);


### PR DESCRIPTION
        gas/testsuite/gas/riscv:
           * cv-hwlp-count.d: Changed encodings to CV32E40P
           * cv-hwlp-counti.d: Likewise. 
           * cv-hwlp-endi.d: Likewise. 
           * cv-hwlp-march-rv32i-xcorev.d: Likewise. 
           * cv-hwlp-march-rv32i-xcorev.s: Likewise. 
           * cv-hwlp-setup.d: Likewise. 
           * cv-hwlp-setupi.d: Likewise. 
           * cv-hwlp-starti.d: Likewise.

        include/opcode:
           * riscv-opc.h: Changed encodings to CV32E40P.

        opcodes:
           * riscv-dis.c: Mask rd to only print 1 bit for operand d1.