### PR TITLE
Changed the immediate order in bit maipulation instructions

### DIFF
--- a/gas/testsuite/gas/riscv/cv-bitmanip-march-xcorev.d
+++ b/gas/testsuite/gas/riscv/cv-bitmanip-march-xcorev.d
@@ -8,12 +8,12 @@
 Disassembly of section .text:
 
 0+000 <target>:
-[  ]+0:[ 	]+28a502db[ 	]+cv.extract	t0,a0,10,20
-[  ]+4:[ 	]+68f4835b[ 	]+cv.extractu	t1,s1,15,20
+[  ]+0:[ 	]+28a502db[ 	]+cv.extract	t0,a0,20,10
+[  ]+4:[ 	]+68f4835b[ 	]+cv.extractu	t1,s1,20,15
 [  ]+8:[ 	]+a94403db[ 	]+cv.insert	t2,s0,20,20
-[  ]+c:[ 	]+2993945b[ 	]+cv.bclr	s0,t2,25,20
-[  ]+10:[ 	]+69e314db[ 	]+cv.bset	s1,t1,30,20
-[  ]+14:[ 	]+c652955b[ 	]+cv.bitrev	a0,t0,5,3
+[  ]+c:[ 	]+2993945b[ 	]+cv.bclr	s0,t2,20,25
+[  ]+10:[ 	]+69e314db[ 	]+cv.bset	s1,t1,20,30
+[  ]+14:[ 	]+c652955b[ 	]+cv.bitrev	a0,t0,3,5
 [  ]+18:[ 	]+307332ab[ 	]+cv.extractr	t0,t1,t2
 [  ]+1c:[ 	]+327332ab[ 	]+cv.extractur	t0,t1,t2
 [  ]+20:[ 	]+347332ab[ 	]+cv.insertr	t0,t1,t2

--- a/gas/testsuite/gas/riscv/cv-bitmanip-march-xcorev.s
+++ b/gas/testsuite/gas/riscv/cv-bitmanip-march-xcorev.s
@@ -1,10 +1,10 @@
 target: 
-    cv.extract x5, x10, 10, 20
-    cv.extractu x6, x9, 15, 20
+    cv.extract x5, x10, 20, 10
+    cv.extractu x6, x9, 20, 15
     cv.insert x7, x8, 20, 20
-    cv.bclr x8, x7, 25, 20
-    cv.bset x9, x6, 30, 20
-    cv.bitrev x10, x5, 5, 3
+    cv.bclr x8, x7, 20, 25
+    cv.bset x9, x6, 20, 30
+    cv.bitrev x10, x5, 3, 5
     cv.extractr x5, x6, x7
     cv.extractur x5, x6, x7
     cv.insertr x5, x6, x7

--- a/gas/testsuite/gas/riscv/cv-bitmanip-march-xcorevbitmanip.d
+++ b/gas/testsuite/gas/riscv/cv-bitmanip-march-xcorevbitmanip.d
@@ -13,7 +13,7 @@ Disassembly of section .text:
 [  ]+8:[ 	]+a943835b[ 	]+cv.insert	t1,t2,20,20
 [  ]+c:[ 	]+2943935b[ 	]+cv.bclr	t1,t2,20,20
 [  ]+10:[ 	]+6943935b[ 	]+cv.bset	t1,t2,20,20
-[  ]+14:[ 	]+c743935b[ 	]+cv.bitrev	t1,t2,20,3
+[  ]+14:[ 	]+c743935b[ 	]+cv.bitrev	t1,t2,3,20
 [  ]+18:[ 	]+307332ab[ 	]+cv.extractr	t0,t1,t2
 [  ]+1c:[ 	]+327332ab[ 	]+cv.extractur	t0,t1,t2
 [  ]+20:[ 	]+347332ab[ 	]+cv.insertr	t0,t1,t2

--- a/gas/testsuite/gas/riscv/cv-bitmanip-march-xcorevbitmanip.s
+++ b/gas/testsuite/gas/riscv/cv-bitmanip-march-xcorevbitmanip.s
@@ -4,7 +4,7 @@ target:
     cv.insert x6, x7, 20, 20
     cv.bclr x6, x7, 20, 20
     cv.bset x6, x7, 20, 20
-    cv.bitrev x6, x7, 20, 3
+    cv.bitrev x6, x7, 3, 20
     cv.extractr x5, x6, x7
     cv.extractur x5, x6, x7
     cv.insertr x5, x6, x7

--- a/gas/testsuite/gas/riscv/cv-bitrev-fail.l
+++ b/gas/testsuite/gas/riscv/cv-bitrev-fail.l
@@ -1,7 +1,7 @@
 .*: Assembler messages:
-.*: Error: illegal operands `cv.bitrev x32,x32,20,2'
-.*: Error: illegal operands `cv.bitrev x33,x33,20,2'
+.*: Error: illegal operands `cv.bitrev x32,x32,2,20'
+.*: Error: illegal operands `cv.bitrev x33,x33,2,20'
 .*: Error: illegal operands `cv.bitrev x6,x7,-1,0'
 .*: Error: illegal operands `cv.bitrev x6,x7,0,-1'
-.*: Error: illegal operands `cv.bitrev x6,x7,32,0'
-.*: Error: illegal operands `cv.bitrev x6,x7,0,4'
+.*: Error: illegal operands `cv.bitrev x6,x7,0,32'
+.*: Error: illegal operands `cv.bitrev x6,x7,4,0'

--- a/gas/testsuite/gas/riscv/cv-bitrev-fail.s
+++ b/gas/testsuite/gas/riscv/cv-bitrev-fail.s
@@ -1,9 +1,9 @@
 target:
     #Register Tests
-    cv.bitrev x32, x32, 20, 2
-    cv.bitrev x33, x33, 20, 2
+    cv.bitrev x32, x32, 2, 20
+    cv.bitrev x33, x33, 2, 20
     #Immediate Values Test
     cv.bitrev x6, x7, -1, 0
     cv.bitrev x6, x7, 0, -1
-    cv.bitrev x6, x7, 32, 0
-    cv.bitrev x6, x7, 0, 4
+    cv.bitrev x6, x7, 0, 32
+    cv.bitrev x6, x7, 4, 0

--- a/gas/testsuite/gas/riscv/cv-bitrev-pass.d
+++ b/gas/testsuite/gas/riscv/cv-bitrev-pass.d
@@ -8,11 +8,11 @@
 Disassembly of section .text:
 
 0+000 <target>:
-   0:	c540105b          	cv.bitrev	zero,zero,20,2
-   4:	c54090db          	cv.bitrev	ra,ra,20,2
-   8:	c541115b          	cv.bitrev	sp,sp,20,2
-   c:	c544145b          	cv.bitrev	s0,s0,20,2
-  10:	c54a1a5b          	cv.bitrev	s4,s4,20,2
-  14:	c54f9fdb          	cv.bitrev	t6,t6,20,2
+   0:	c540105b          	cv.bitrev	zero,zero,2,20
+   4:	c54090db          	cv.bitrev	ra,ra,2,20
+   8:	c541115b          	cv.bitrev	sp,sp,2,20
+   c:	c544145b          	cv.bitrev	s0,s0,2,20
+  10:	c54a1a5b          	cv.bitrev	s4,s4,2,20
+  14:	c54f9fdb          	cv.bitrev	t6,t6,2,20
   18:	c003935b          	cv.bitrev	t1,t2,0,0
-  1c:	c7f3935b          	cv.bitrev	t1,t2,31,3
+  1c:	c7f3935b          	cv.bitrev	t1,t2,3,31

--- a/gas/testsuite/gas/riscv/cv-bitrev-pass.s
+++ b/gas/testsuite/gas/riscv/cv-bitrev-pass.s
@@ -1,11 +1,11 @@
 target:
     #Register Tests
-    cv.bitrev x0, x0, 20, 2
-    cv.bitrev x1, x1, 20, 2
-    cv.bitrev x2, x2, 20, 2
-    cv.bitrev x8, x8, 20, 2
-    cv.bitrev x20, x20, 20, 2
-    cv.bitrev x31, x31, 20, 2
+    cv.bitrev x0, x0, 2, 20
+    cv.bitrev x1, x1, 2, 20
+    cv.bitrev x2, x2, 2, 20
+    cv.bitrev x8, x8, 2, 20
+    cv.bitrev x20, x20, 2, 20
+    cv.bitrev x31, x31, 2, 20
     #Immediate Values Test
     cv.bitrev x6, x7, 0, 0
-    cv.bitrev x6, x7, 31, 3
+    cv.bitrev x6, x7, 3, 31

--- a/opcodes/riscv-opc.c
+++ b/opcodes/riscv-opc.c
@@ -2161,12 +2161,12 @@ const struct riscv_opcode riscv_opcodes[] =
 {"cv.clb",          0, INSN_CLASS_COREV_BITMANIP, "d,s",   MATCH_CV_CLB, MASK_CV_CLB, match_opcode, 0},
 {"cv.cnt",          0, INSN_CLASS_COREV_BITMANIP, "d,s",   MATCH_CV_CNT, MASK_CV_CNT, match_opcode, 0},
 
-{"cv.extract",      0, INSN_CLASS_COREV_BITMANIP, "d,s,bi,b6", MATCH_CV_EXTRACT, MASK_CV_EXTRACT, match_opcode, 0},
-{"cv.extractu",     0, INSN_CLASS_COREV_BITMANIP, "d,s,bi,b6", MATCH_CV_EXTRACTU, MASK_CV_EXTRACTU, match_opcode, 0},
-{"cv.insert",       0, INSN_CLASS_COREV_BITMANIP, "d,s,bi,b6", MATCH_CV_INSERT, MASK_CV_INSERT, match_opcode, 0},
-{"cv.bclr",         0, INSN_CLASS_COREV_BITMANIP, "d,s,bi,b6", MATCH_CV_BCLR, MASK_CV_BCLR, match_opcode, 0},
-{"cv.bset",         0, INSN_CLASS_COREV_BITMANIP, "d,s,bi,b6", MATCH_CV_BSET, MASK_CV_BSET, match_opcode, 0},
-{"cv.bitrev",       0, INSN_CLASS_COREV_BITMANIP, "d,s,bi,b7", MATCH_CV_BITREV, MASK_CV_BITREV, match_opcode, 0},
+{"cv.extract",      0, INSN_CLASS_COREV_BITMANIP, "d,s,b6,bi", MATCH_CV_EXTRACT, MASK_CV_EXTRACT, match_opcode, 0},
+{"cv.extractu",     0, INSN_CLASS_COREV_BITMANIP, "d,s,b6,bi", MATCH_CV_EXTRACTU, MASK_CV_EXTRACTU, match_opcode, 0},
+{"cv.insert",       0, INSN_CLASS_COREV_BITMANIP, "d,s,b6,bi", MATCH_CV_INSERT, MASK_CV_INSERT, match_opcode, 0},
+{"cv.bclr",         0, INSN_CLASS_COREV_BITMANIP, "d,s,b6,bi", MATCH_CV_BCLR, MASK_CV_BCLR, match_opcode, 0},
+{"cv.bset",         0, INSN_CLASS_COREV_BITMANIP, "d,s,b6,bi", MATCH_CV_BSET, MASK_CV_BSET, match_opcode, 0},
+{"cv.bitrev",       0, INSN_CLASS_COREV_BITMANIP, "d,s,b7,bi", MATCH_CV_BITREV, MASK_CV_BITREV, match_opcode, 0},
 
 
 /* END OF CORE-V */


### PR DESCRIPTION
==Related Issues==
Issue #68 

==Commit==

Files Changed:

gas/testsuite/gas/riscv:
 * cv-bitmanip-march-xcorev.d: Updated the tests with the changed immediate order. cv-bitmanip-march-xcorev.s: Likewise.
cv-bitmanip-march-xcorevbitmanip.d: Likewise.
cv-bitmanip-march-xcorevbitmanip.s: Likewise.
cv-bitrev-fail.l: Likewise.
cv-bitrev-fail.s: Likewise.
cv-bitrev-pass.d: Likewise.
cv-bitrev-pass.s: Likewise.

opcodes:
 * riscv-opc.c: Changed the order of ls2 and ls3 in instructions cv.extract, cv.instert, cv.bclr, cv.bset, and cv.bitrev.

==Results==
No change

===GAS===
| Category             | Previous | With commit | Delta |
| -------------------: | -------: | ----------: | ----: |
| Expected passes      |     1270 |      1270 |  - |
| Unexpected failures  |       - |          - |     - | 
| Unexpected successes |        - |           - |     - | 
| Expected failures    |       23 |          23 |     - | 
| Unresolved testcases |        - |         - |     - | 
| Unsupported tests    |      9 |        9 |     - |