### PR TITLE
Updated relocation tests with cv32e40pv2 encodings

### DIFF
--- a/ld/testsuite/ld-riscv-elf/cv-bi-beqimm.d
+++ b/ld/testsuite/ld-riscv-elf/cv-bi-beqimm.d
@@ -13,7 +13,7 @@ Disassembly of section \.text:
 .*:[[:space:]]+00008067[[:space:]]+ret
 
 .* <_start>:
-.*:[[:space:]]+0102a463[[:space:]]+cv.beqimm[[:space:]]+t0,-16,.*[[:space:]]+<L2>
+.*:[[:space:]]+0102e40b[[:space:]]+cv.beqimm[[:space:]]+t0,-16,.*[[:space:]]+<L2>
 .*:[[:space:]]+ff9ff0ef[[:space:]]+jal[[:space:]]+ra,.*[[:space:]]+<func>
 
 .* <L2>:

--- a/ld/testsuite/ld-riscv-elf/cv-bi-bneimm.d
+++ b/ld/testsuite/ld-riscv-elf/cv-bi-bneimm.d
@@ -13,7 +13,7 @@ Disassembly of section \.text:
 .*:[[:space:]]+00008067[[:space:]]+ret
 
 .* <_start>:
-.*:[[:space:]]+0102b463[[:space:]]+cv.bneimm[[:space:]]+t0,-16,.*[[:space:]]+<L2>
+.*:[[:space:]]+0102f40b[[:space:]]+cv.bneimm[[:space:]]+t0,-16,.*[[:space:]]+<L2>
 .*:[[:space:]]+ff9ff0ef[[:space:]]+jal[[:space:]]+ra,.*[[:space:]]+<func>
 
 .* <L2>:


### PR DESCRIPTION
Files Changed:

ld/testsuite/ld-riscv-elf:
 * cv-bi-beqimm.d: Updated encoding of CORE-V instruction.
 * cv-bi-bneimm.d: Likewise.

==Results==
===LD===
| Category             | Previous | With commit | Delta |
| -------------------: | -------: | ----------: | ----: |
| Expected passes      |    431  |     433 |  +2 |
| Unexpected failures  |    2 |  0 |    -2 | 
| Unexpected successes |        - |           - |     - | 
| Expected failures    |      16 |       16 |     - | 
| Unresolved testcases |      3 |         3 |     - |
| Untested testcases | 20 | 20 | - | 
| Unsupported tests    |      200 |        200 |     - |