### PR TITLE
Fixed linker failer due to cm.jt/cm.jalt change

### DIFF
--- a/ld/testsuite/ld-riscv-elf/zc-zcmt-jump-table-2.d
+++ b/ld/testsuite/ld-riscv-elf/zc-zcmt-jump-table-2.d
@@ -14,10 +14,10 @@ Disassembly of section .text:
 	...
 
 0+[0-9a-f]+ <_start>:
-.*:[ 	]+[0-9a-f]+[ 	]+cm.jalt[ 	]+64
+.*:[ 	]+[0-9a-f]+[ 	]+cm.jt[ 	]+32
 .*:[ 	]+[0-9a-f]+[ 	]+ret
 	...
 
 0+[0-9a-f]+ <__jvt_base\$>:
 	...
-.*:[ 	]+[0-9a-f]+[ 	]+index 64[ 	]+[^<]+<bar>
+.*:[ 	]+[0-9a-f]+[ 	]+index 32[ 	]+[^<]+<bar>

--- a/ld/testsuite/ld-riscv-elf/zc-zcmt-jump-table.d
+++ b/ld/testsuite/ld-riscv-elf/zc-zcmt-jump-table.d
@@ -16,8 +16,8 @@ Disassembly of section .text:
 .*:[ 	]+[0-9a-f]+[ 	]+ret
 
 0+[0-9a-f]+ <_start>:
-.*:[ 	]+[0-9a-f]+[ 	]+cm.jalt[ 	]+64
-.*:[ 	]+[0-9a-f]+[ 	]+cm.jalt[ 	]+65
+.*:[ 	]+[0-9a-f]+[ 	]+cm.jt[ 	]+64
+.*:[ 	]+[0-9a-f]+[ 	]+cm.jt[ 	]+65
 .*:[ 	]+[0-9a-f]+[ 	]+ret
 	...
 


### PR DESCRIPTION
Files Changed:

ld/testsuite/ld-riscv-elf:
 * zc-zcmt-jump-table-2.d: Changed the expected output to cm.jt 32 instead of cm.jalt 64.
 * zc-zcmt-jump-table.d: Likewise.