### PR TITLE
RISC-V: skip unrelated relocations in table jump relaxation phrase

### DIFF
--- a/bfd/elfnn-riscv.c
+++ b/bfd/elfnn-riscv.c
@@ -5382,6 +5382,11 @@ _bfd_riscv_relax_section (bfd *abfd, asection *sec,
 	  if (!riscv_use_table_jump (info))
 	    return true;
 
+	  if (!(type == R_RISCV_CALL
+	      || type == R_RISCV_CALL_PLT
+	      || type == R_RISCV_JAL))
+	    continue;
+
 	  if (info->relax_trip == 0)
 	    {
 	      if (type == R_RISCV_CALL


### PR DESCRIPTION
Add check to skip relocations that are not R_RISCV_JAL/R_RISCV_CALL[PLT]. This fixes issue #81.

Edit: I believe this fixes #49