### PR TITLE
RISC-V: Fix .option arch compatibility with zc*

### DIFF
--- a/gas/config/tc-riscv.c
+++ b/gas/config/tc-riscv.c
@@ -4669,6 +4669,8 @@ s_riscv_option (int x ATTRIBUTE_UNUSED)
     {
       riscv_update_subset (&riscv_rps_as, "-c");
       riscv_set_rvc (false);
+      if (riscv_subset_supports (&riscv_rps_as, "zca"))
+	riscv_set_rvc (true);
     }
   else if (strcmp (name, "pic") == 0)
     riscv_opts.pic = true;
@@ -4690,7 +4692,8 @@ s_riscv_option (int x ATTRIBUTE_UNUSED)
       riscv_update_subset (&riscv_rps_as, name);
 
       riscv_set_rvc (false);
-      if (riscv_subset_supports (&riscv_rps_as, "c"))
+      if (riscv_subset_supports (&riscv_rps_as, "c")
+	  || riscv_subset_supports (&riscv_rps_as, "zca"))
 	riscv_set_rvc (true);
     }
   else if (strcmp (name, "push") == 0)

--- a/gas/testsuite/gas/riscv/zc-zca-option-march.d
+++ b/gas/testsuite/gas/riscv/zc-zca-option-march.d
@@ -1,0 +1,12 @@
+#as: -march=rv32i
+#source: zc-zca-option-march.s
+#objdump: -d -Mno-aliases
+
+.*:[ 	]+file format .*
+
+
+Disassembly of section .text:
+
+0+000 <testcase>:
+[ 	]+0:[ 	]+0001[ 	]+c.addi[ 	]+zero,0
+#...

--- a/gas/testsuite/gas/riscv/zc-zca-option-march.s
+++ b/gas/testsuite/gas/riscv/zc-zca-option-march.s
@@ -1,0 +1,6 @@
+	.attribute 5, "rv32i"
+    .option rvc
+	.option arch, +zca
+    .option norvc
+testcase:
+	c.nop

--- a/gas/testsuite/gas/riscv/zc-zcmt-emit-jal-relax.s
+++ b/gas/testsuite/gas/riscv/zc-zcmt-emit-jal-relax.s
@@ -1,6 +1,7 @@
 .macro PADDIING_32_BYTES
 	.option push
-	.option norvc
+	.option arch, -zcmt
+	.option arch, -zca
 	nop
 	nop
 	nop

--- a/gas/testsuite/gas/riscv/zc-zcmt-relax-c-branch.s
+++ b/gas/testsuite/gas/riscv/zc-zcmt-relax-c-branch.s
@@ -1,6 +1,7 @@
 .macro PADDIING_32_BYTES
 	.option push
-	.option norvc
+	.option arch, -zcmt
+	.option arch, -zca
 	nop
 	nop
 	nop


### PR DESCRIPTION
This fixes an issue whereby .option arch with the zc extensions can result in gas refusing to accept otherwise valid instructions because the base C extension is not enabled.