### PR TITLE
CV32E40Pv2 MAC pseudo-instructions

### DIFF
--- a/gas/testsuite/gas/riscv/cv-mac-mulhhs.d
+++ b/gas/testsuite/gas/riscv/cv-mac-mulhhs.d
@@ -7,6 +7,9 @@
 Disassembly of section .text:
 
 0+000 <target>:
-[ 	]+0:[ 	]+c07302db[ 	]+cv.mulhhs[ 	]+t0,t1,t2
-[ 	]+4:[ 	]+c0538edb[ 	]+cv.mulhhs[ 	]+t4,t2,t0
-[ 	]+8:[ 	]+c06f0e5b[ 	]+cv.mulhhs[ 	]+t3,t5,t1
+[ 	]+0:[ 	]+407342db[ 	]+cv.mulhhsn[ 	]+t0,t1,t2,0
+[ 	]+4:[ 	]+407342db[ 	]+cv.mulhhsn[ 	]+t0,t1,t2,0
+[ 	]+8:[ 	]+4053cedb[ 	]+cv.mulhhsn[ 	]+t4,t2,t0,0
+[ 	]+c:[ 	]+4053cedb[ 	]+cv.mulhhsn[ 	]+t4,t2,t0,0
+[ 	]+10:[ 	]+406f4e5b[ 	]+cv.mulhhsn[ 	]+t3,t5,t1,0
+[ 	]+14:[ 	]+406f4e5b[ 	]+cv.mulhhsn[ 	]+t3,t5,t1,0

--- a/gas/testsuite/gas/riscv/cv-mac-mulhhs.s
+++ b/gas/testsuite/gas/riscv/cv-mac-mulhhs.s
@@ -1,4 +1,7 @@
 target:
 	cv.mulhhs t0, t1, t2
+	cv.mulhhsn t0, t1, t2, 0
 	cv.mulhhs t4, t2, t0
+	cv.mulhhsn t4, t2, t0, 0
 	cv.mulhhs t3, t5, t1
+	cv.mulhhsn t3, t5, t1, 0

--- a/gas/testsuite/gas/riscv/cv-mac-mulhhu.d
+++ b/gas/testsuite/gas/riscv/cv-mac-mulhhu.d
@@ -7,6 +7,9 @@
 Disassembly of section .text:
 
 0+000 <target>:
-[ 	]+0:[ 	]+407302db[ 	]+cv.mulhhu[ 	]+t0,t1,t2
-[ 	]+4:[ 	]+40538edb[ 	]+cv.mulhhu[ 	]+t4,t2,t0
-[ 	]+8:[ 	]+406f0e5b[ 	]+cv.mulhhu[ 	]+t3,t5,t1
+[ 	]+0:[ 	]+407352db[ 	]+cv.mulhhun[ 	]+t0,t1,t2,0
+[ 	]+4:[ 	]+407352db[ 	]+cv.mulhhun[ 	]+t0,t1,t2,0
+[ 	]+8:[ 	]+4053dedb[ 	]+cv.mulhhun[ 	]+t4,t2,t0,0
+[ 	]+c:[ 	]+4053dedb[ 	]+cv.mulhhun[ 	]+t4,t2,t0,0
+[ 	]+10:[ 	]+406f5e5b[ 	]+cv.mulhhun[ 	]+t3,t5,t1,0
+[ 	]+14:[ 	]+406f5e5b[ 	]+cv.mulhhun[ 	]+t3,t5,t1,0

--- a/gas/testsuite/gas/riscv/cv-mac-mulhhu.s
+++ b/gas/testsuite/gas/riscv/cv-mac-mulhhu.s
@@ -1,4 +1,7 @@
 target:
 	cv.mulhhu t0, t1, t2
+	cv.mulhhun t0, t1, t2, 0
 	cv.mulhhu t4, t2, t0
+	cv.mulhhun t4, t2, t0, 0
 	cv.mulhhu t3, t5, t1
+	cv.mulhhun t3, t5, t1, 0

--- a/gas/testsuite/gas/riscv/cv-mac-muls.d
+++ b/gas/testsuite/gas/riscv/cv-mac-muls.d
@@ -7,6 +7,9 @@
 Disassembly of section .text:
 
 0+000 <target>:
-[ 	]+0:[ 	]+807302db[ 	]+cv.muls[ 	]+t0,t1,t2
-[ 	]+4:[ 	]+80538edb[ 	]+cv.muls[ 	]+t4,t2,t0
-[ 	]+8:[ 	]+806f0e5b[ 	]+cv.muls[ 	]+t3,t5,t1
+[ 	]+0:[ 	]+007342db[ 	]+cv.mulsn[ 	]+t0,t1,t2,0
+[ 	]+4:[ 	]+007342db[ 	]+cv.mulsn[ 	]+t0,t1,t2,0
+[ 	]+8:[ 	]+0053cedb[ 	]+cv.mulsn[ 	]+t4,t2,t0,0
+[ 	]+c:[ 	]+0053cedb[ 	]+cv.mulsn[ 	]+t4,t2,t0,0
+[ 	]+10:[ 	]+006f4e5b[ 	]+cv.mulsn[ 	]+t3,t5,t1,0
+[ 	]+14:[ 	]+006f4e5b[ 	]+cv.mulsn[ 	]+t3,t5,t1,0

--- a/gas/testsuite/gas/riscv/cv-mac-muls.s
+++ b/gas/testsuite/gas/riscv/cv-mac-muls.s
@@ -1,4 +1,7 @@
 target:
 	cv.muls t0, t1, t2
+	cv.mulsn t0, t1, t2, 0
 	cv.muls t4, t2, t0
+	cv.mulsn t4, t2, t0, 0
 	cv.muls t3, t5, t1
+	cv.mulsn t3, t5, t1, 0

--- a/gas/testsuite/gas/riscv/cv-mac-mulu.d
+++ b/gas/testsuite/gas/riscv/cv-mac-mulu.d
@@ -7,6 +7,9 @@
 Disassembly of section .text:
 
 0+000 <target>:
-[ 	]+0:[ 	]+007302db[ 	]+cv.mulu[ 	]+t0,t1,t2
-[ 	]+4:[ 	]+00538edb[ 	]+cv.mulu[ 	]+t4,t2,t0
-[ 	]+8:[ 	]+006f0e5b[ 	]+cv.mulu[ 	]+t3,t5,t1
+[ 	]+0:[ 	]+007352db[ 	]+cv.mulun[ 	]+t0,t1,t2,0
+[ 	]+4:[ 	]+007352db[ 	]+cv.mulun[ 	]+t0,t1,t2,0
+[ 	]+8:[ 	]+0053dedb[ 	]+cv.mulun[ 	]+t4,t2,t0,0
+[ 	]+c:[ 	]+0053dedb[ 	]+cv.mulun[ 	]+t4,t2,t0,0
+[ 	]+10:[ 	]+006f5e5b[ 	]+cv.mulun[ 	]+t3,t5,t1,0
+[ 	]+14:[ 	]+006f5e5b[ 	]+cv.mulun[ 	]+t3,t5,t1,0

--- a/gas/testsuite/gas/riscv/cv-mac-mulu.s
+++ b/gas/testsuite/gas/riscv/cv-mac-mulu.s
@@ -1,4 +1,7 @@
 target:
 	cv.mulu t0, t1, t2
+	cv.mulun t0, t1, t2, 0
 	cv.mulu t4, t2, t0
+	cv.mulun t4, t2, t0, 0
 	cv.mulu t3, t5, t1
+	cv.mulun t3, t5, t1, 0

--- a/include/opcode/riscv-opc.h
+++ b/include/opcode/riscv-opc.h
@@ -2854,13 +2854,6 @@
 
 #define MASK_CV_MACMSU     0xfe00707f
 
-#define MATCH_CV_MULS      0x8000005b
-#define MATCH_CV_MULHHS    0xc000005b
-#define MATCH_CV_MULU      0x5b
-#define MATCH_CV_MULHHU    0x4000005b
-
-#define MASK_CV_MULSH      0xfe00707f
-
 #define MATCH_CV_MULSN     0x405b
 #define MATCH_CV_MULHHSN   0x4000405b
 #define MATCH_CV_MULSRN    0x8000405b

--- a/opcodes/riscv-opc.c
+++ b/opcodes/riscv-opc.c
@@ -132,6 +132,7 @@ const char * const riscv_vma[2] =
 #define MASK_RD (OP_MASK_RD << OP_SH_RD)
 #define MASK_CRS2 (OP_MASK_CRS2 << OP_SH_CRS2)
 #define MASK_IMM ENCODE_ITYPE_IMM (-1U)
+#define MASK_CV_MAC_UIMM5 ENCODE_CV_MAC_UIMM5 (-1U)
 #define MASK_RVC_IMM ENCODE_CITYPE_IMM (-1U)
 #define MASK_UIMM ENCODE_UTYPE_IMM (-1U)
 #define MASK_RM (OP_MASK_RM << OP_SH_RM)
@@ -2050,17 +2051,19 @@ const struct riscv_opcode riscv_opcodes[] =
 /* Multiply accumulate */
 {"cv.mac",      0, INSN_CLASS_CV_MAC, "d,s,t",	MATCH_CV_MAC,		MASK_CV_MACMSU,	 match_opcode, 0},
 {"cv.msu",      0, INSN_CLASS_CV_MAC, "d,s,t",	MATCH_CV_MSU,		MASK_CV_MACMSU,	 match_opcode, 0},
-{"cv.muls",     0, INSN_CLASS_CV_MAC, "d,s,t",	MATCH_CV_MULS,		MASK_CV_MULSH,	 match_opcode, 0},
-{"cv.mulhhs",   0, INSN_CLASS_CV_MAC, "d,s,t",	MATCH_CV_MULHHS,	MASK_CV_MULSH,	 match_opcode, 0},
+
+
 {"cv.mulsn",    0, INSN_CLASS_CV_MAC, "d,s,t,b3",	MATCH_CV_MULSN,		MASK_CV_MULMACN, match_opcode, 0},
-{"cv.mulhhsn",  0, INSN_CLASS_CV_MAC, "d,s,t,b3",	MATCH_CV_MULHHSN,	MASK_CV_MULMACN, match_opcode, 0},
+{"cv.muls",     0, INSN_CLASS_CV_MAC, "d,s,t",		MATCH_CV_MULSN,		MASK_CV_MULMACN|MASK_CV_MAC_UIMM5,	 match_opcode, INSN_ALIAS},
 {"cv.mulsrn",   0, INSN_CLASS_CV_MAC, "d,s,t,b3",	MATCH_CV_MULSRN,	MASK_CV_MULMACN, match_opcode, 0},
+{"cv.mulhhsn",  0, INSN_CLASS_CV_MAC, "d,s,t,b3",	MATCH_CV_MULHHSN,	MASK_CV_MULMACN, match_opcode, 0},
+{"cv.mulhhs",   0, INSN_CLASS_CV_MAC, "d,s,t",		MATCH_CV_MULHHSN,	MASK_CV_MULMACN|MASK_CV_MAC_UIMM5,	 match_opcode, INSN_ALIAS},
 {"cv.mulhhsrn", 0, INSN_CLASS_CV_MAC, "d,s,t,b3",	MATCH_CV_MULHHSRN,	MASK_CV_MULMACN, match_opcode, 0},
-{"cv.mulu",     0, INSN_CLASS_CV_MAC, "d,s,t",	MATCH_CV_MULU,		MASK_CV_MULSH,	 match_opcode, 0},
-{"cv.mulhhu",   0, INSN_CLASS_CV_MAC, "d,s,t",	MATCH_CV_MULHHU,	MASK_CV_MULSH,	 match_opcode, 0},
 {"cv.mulun",    0, INSN_CLASS_CV_MAC, "d,s,t,b3",	MATCH_CV_MULUN,		MASK_CV_MULMACN, match_opcode, 0},
-{"cv.mulhhun",  0, INSN_CLASS_CV_MAC, "d,s,t,b3",	MATCH_CV_MULHHUN,	MASK_CV_MULMACN, match_opcode, 0},
+{"cv.mulu",     0, INSN_CLASS_CV_MAC, "d,s,t",		MATCH_CV_MULUN,		MASK_CV_MULMACN|MASK_CV_MAC_UIMM5,	 match_opcode, INSN_ALIAS},
 {"cv.mulurn",   0, INSN_CLASS_CV_MAC, "d,s,t,b3",	MATCH_CV_MULURN,	MASK_CV_MULMACN, match_opcode, 0},
+{"cv.mulhhun",  0, INSN_CLASS_CV_MAC, "d,s,t,b3",	MATCH_CV_MULHHUN,	MASK_CV_MULMACN, match_opcode, 0},
+{"cv.mulhhu",   0, INSN_CLASS_CV_MAC, "d,s,t",		MATCH_CV_MULHHUN,	MASK_CV_MULMACN|MASK_CV_MAC_UIMM5,	 match_opcode, INSN_ALIAS},
 {"cv.mulhhurn", 0, INSN_CLASS_CV_MAC, "d,s,t,b3",	MATCH_CV_MULHHURN,	MASK_CV_MULMACN, match_opcode, 0},
 {"cv.macsn",    0, INSN_CLASS_CV_MAC, "d,s,t,b3",	MATCH_CV_MACSN,		MASK_CV_MULMACN, match_opcode, 0},
 {"cv.machhsn",  0, INSN_CLASS_CV_MAC, "d,s,t,b3",	MATCH_CV_MACHHSN,	MASK_CV_MULMACN, match_opcode, 0},


### PR DESCRIPTION
	This is where `cv.mul* rD, rs1, rs2` is `cv.mul*n rD, rs1, rs2, 0`.

	* include/opcode/riscv-opc.h: Removed corresponding MATCH and MASK macros.
	* opcodes/riscv-opc.c: Implemented:
		* MASK_CV_MAC_UIMM5 macro which masks 0 for Is3 operand
		* infrastructure for CORE-V MAC alias instructions.
	* gas/testsuite/gas/riscv/cv-mac-mulhhs.d: Updated tests.
	* gas/testsuite/gas/riscv/cv-mac-mulhhs.s: Likewise.
	* gas/testsuite/gas/riscv/cv-mac-mulhhu.d: Likewise.
	* gas/testsuite/gas/riscv/cv-mac-mulhhu.s: Likewise.
	* gas/testsuite/gas/riscv/cv-mac-muls.d: Likewise.
	* gas/testsuite/gas/riscv/cv-mac-muls.s: Likewise.
	* gas/testsuite/gas/riscv/cv-mac-mulu.d: Likewise.
	* gas/testsuite/gas/riscv/cv-mac-mulu.s: Likewise.